### PR TITLE
Add quay.io prefix to gfdatasource image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Boiler plate for bulding Docker containers.
 # All this must go at top of file I'm afraid.
-IMAGE_PREFIX := weaveworks
+IMAGE_PREFIX := quay.io/weaveworks
 IMAGE_TAG := $(shell ./tools/image-tag)
 UPTODATE := .uptodate
 


### PR DESCRIPTION
@tomwilkie This solved an issue for me when standing up a `minikube` k8s cluster. Also, can I pretty please have write access to the repo via our org?