### PR TITLE
Stop pushing to Docker Hub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,8 +21,6 @@ deployment:
   push:
     branch: master
     commands:
-      - docker login -e "$DOCKER_REGISTRY_EMAIL" -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
-      - docker push weaveworks/gfdatasource:$(./tools/image-tag)
       - docker login -e '.' -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io
       - docker tag weaveworks/gfdatasource:$(./tools/image-tag) quay.io/weaveworks/gfdatasource:$(./tools/image-tag)
       - docker push quay.io/weaveworks/gfdatasource:$(./tools/image-tag)


### PR DESCRIPTION
We're getting 404s when pushing & pulling from
hub.docker.io/weaveworks/gfdatasource. Just stop pushing/pulling there and use
only quay.io.