### PR TITLE
zabbix.py lint tests fixed

### DIFF
--- a/grafanalib/zabbix.py
+++ b/grafanalib/zabbix.py
@@ -1,7 +1,7 @@
 import attr
 from attr.validators import instance_of
 from numbers import Number
-from grafanalib.validators import *
+from grafanalib.validators import is_interval, is_in
 
 ZABBIX_QMODE_METRICS = 0
 ZABBIX_QMODE_SERVICES = 1


### PR DESCRIPTION
I've noticed lint tests failing on zabbix.py

```
.env/bin/flake8 gfdatasource/gfdatasource grafanalib
grafanalib/zabbix.py:4:1: F403 'from grafanalib.validators import *' used; unable to detect undefined names
grafanalib/zabbix.py:161:61: F405 'is_interval' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:163:34: F405 'is_in' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:236:61: F405 'is_interval' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:238:34: F405 'is_in' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:275:61: F405 'is_interval' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:309:61: F405 'is_interval' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:343:48: F405 'is_interval' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:377:61: F405 'is_interval' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:437:34: F405 'is_in' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:473:34: F405 'is_in' may be undefined, or defined from star imports: grafanalib.validators
grafanalib/zabbix.py:512:30: F405 'is_in' may be undefined, or defined from star imports: grafanalib.validators
make: *** [lint] Error 1
```

here is fix. 