### PR TITLE
Fix dashboard example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ percentile latency:
             YAxis(format=SHORT_FORMAT),
           ],
           alert=Alert(
-            name="Too many 500s on Nginx"
+            name="Too many 500s on Nginx",
             message="More than 5 QPS of 500s on Nginx for 5 minutes",
             alertConditions=[
               AlertCondition(
@@ -73,7 +73,7 @@ percentile latency:
                   legendFormat="5xx",
                   refId='A',
                 ),
-                timeRange=TimeRange("5m"),
+                timeRange=TimeRange("5m", "now"),
                 evaluator=GreaterThan(5),
                 operator=OP_AND,
                 reducerType=RTYPE_SUM,

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -550,7 +550,7 @@ class AlertCondition(object):
     type = attr.ib(default=CTYPE_QUERY)
 
     def to_json_data(self):
-        queryParams = [self.target.refId] + self.timeRange
+        queryParams = [self.target.refId, self.timeRange.from_time, self.timeRange.to_time]
         return {
             "evaluator": self.evaluator,
             "operator": {


### PR DESCRIPTION
This PR fixes three problems with the dashboard example in the README:

```
# generate-dashboard -o frontend.json dashboard.py
Traceback (most recent call last):
  File "/usr/bin/generate-dashboard", line 9, in <module>
    load_entry_point('grafanalib==0.1.2', 'console_scripts', 'generate-dashboard')()
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 126, in generate_dashboard_script
    run_script(generate_dashboard)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 116, in run_script
    sys.exit(f(sys.argv[1:]))
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 103, in generate_dashboard
    dashboard = load_dashboard(opts.dashboard)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 24, in load_dashboard
    module = SourceFileLoader("dashboard", path).load_module()
  File "<frozen importlib._bootstrap_external>", line 388, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 809, in load_module
  File "<frozen importlib._bootstrap_external>", line 668, in load_module
  File "<frozen importlib._bootstrap>", line 268, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 661, in exec_module
  File "<frozen importlib._bootstrap_external>", line 767, in get_code
  File "<frozen importlib._bootstrap_external>", line 727, in source_to_code
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/at/trash/dashboard.py", line 46
    message="More than 5 QPS of 500s on Nginx for 5 minutes",
          ^
SyntaxError: invalid syntax
```

```
Traceback (most recent call last):
  File "/usr/bin/generate-dashboard", line 9, in <module>
    load_entry_point('grafanalib==0.1.2', 'console_scripts', 'generate-dashboard')()
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 126, in generate_dashboard_script
    run_script(generate_dashboard)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 116, in run_script
    sys.exit(f(sys.argv[1:]))
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 103, in generate_dashboard
    dashboard = load_dashboard(opts.dashboard)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 24, in load_dashboard
    module = SourceFileLoader("dashboard", path).load_module()
  File "<frozen importlib._bootstrap_external>", line 388, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 809, in load_module
  File "<frozen importlib._bootstrap_external>", line 668, in load_module
  File "<frozen importlib._bootstrap>", line 268, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/home/at/trash/dashboard.py", line 54, in <module>
    timeRange=TimeRange("5m"),
TypeError: __init__() missing 1 required positional argument: 'to_time'
```

```
Traceback (most recent call last):
  File "/usr/bin/generate-dashboard", line 9, in <module>
    load_entry_point('grafanalib==0.1.2', 'console_scripts', 'generate-dashboard')()
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 126, in generate_dashboard_script
    run_script(generate_dashboard)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 116, in run_script
    sys.exit(f(sys.argv[1:]))
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 108, in generate_dashboard
    write_dashboard(dashboard, output)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 46, in write_dashboard
    cls=DashboardEncoder)
  File "/usr/lib/python3.5/json/__init__.py", line 178, in dump
    for chunk in iterable:
  File "/usr/lib/python3.5/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 324, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 437, in _iterencode
    yield from _iterencode(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 324, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 437, in _iterencode
    yield from _iterencode(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 437, in _iterencode
    yield from _iterencode(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib/python3.5/json/encoder.py", line 403, in _iterencode_dict
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 324, in _iterencode_list
    yield from chunks
  File "/usr/lib/python3.5/json/encoder.py", line 436, in _iterencode
    o = _default(o)
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/_gen.py", line 39, in default
    return to_json_data()
  File "/home/at/.local/lib/python3.5/site-packages/grafanalib/core.py", line 553, in to_json_data
    queryParams = [self.target.refId] + self.timeRange
TypeError: can only concatenate list (not "TimeRange") to list
```
