### PR TITLE
Simplify Y axis specification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,33 +3,50 @@ Changelog
 =========
 
 NEXT (YYYY-MM-DD)
------------------
+=================
 
-* ``PromGraph`` now lives in ``grafanalib.prometheus``, and takes a
-  ``data_source`` parameter
+New features
+------------
+
+* OpenTSDB datasource support (https://github.com/weaveworks/grafanalib/pull/27)
+* Grafana Zabbix plugin support
+  (https://github.com/weaveworks/grafanalib/pull/31, https://github.com/weaveworks/grafanalib/pull/36)
 * ``Dashboard`` objects now have an ``auto_panel_id`` method which will
   automatically supply unique panel (i.e. graph) IDs for any panels that don't
   have one set. Dashboard config files no longer need to track their own
   ``GRAPH_ID`` counter.
-* ``SingleStat`` panel class added  (https://github.com/weaveworks/grafanalib/pull/22)
+* Support for ``SingleStat`` panels
+  (https://github.com/weaveworks/grafanalib/pull/22)
+* ``single_y_axis`` helper for the common case of a graph that has only one Y axis
+
+Improvements
+------------
+
+* ``PromGraph`` now lives in ``grafanalib.prometheus``, and takes a
+  ``data_source`` parameter
 * Additional fields for ``Legend``  (https://github.com/weaveworks/grafanalib/pull/25)
-* OpenTSDB datasource support added (https://github.com/weaveworks/grafanalib/pull/27)
-* Additional fields for ``XAxis``   (https://github.com/weaveworks/grafanalib/pull/28)
-* Add support for Grafana Zabbix plugin (https://github.com/weaveworks/grafanalib/pull/31)
-* Add support for Grafana Zabbix Triggers panel (https://github.com/weaveworks/grafanalib/pull/36)
+* Additional fields for ``XAxis``
+  (https://github.com/weaveworks/grafanalib/pull/28)
+* Get an error when you specify the wrong number of Y axes
+
+Changes
+-------
+
+* New ``YAxes`` type for specifying Y axes. Using a list of two ``YAxis``
+  objects is deprecated.
 
 
 0.1.2 (2017-01-02)
-------------------
+==================
 
 * Add support for Grafana Templates (https://github.com/weaveworks/grafanalib/pull/9)
 
 0.1.1 (2016-12-02)
-------------------
+==================
 
 * Include README on PyPI page
 
 0.1.0 (2016-12-02)
-------------------
+==================
 
 Initial release.


### PR DESCRIPTION
- Introduce new `YAxes` type
- Introduce helper `single_y_axis` for common use case
- Add backwards compatibility for converting existing Y axes to new type

Fixes #2 
Fixes #42