### PR TITLE
Respect the `showTitle` option in `Row`

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -391,8 +391,13 @@ class Row(object):
         return attr.assoc(self, panels=list(map(f, self.panels)))
 
     def to_json_data(self):
-        showTitle = False if self.title is None else True
-        title = "New row" if self.title is None else self.title
+        showTitle = False
+        title = "New row"
+        if self.title is not None:
+            showTitle = True
+            title = self.title
+        if self.showTitle is not None:
+            showTitle = self.showTitle
         return {
             'collapse': self.collapse,
             'editable': self.editable,

--- a/grafanalib/tests/test_grafanalib.py
+++ b/grafanalib/tests/test_grafanalib.py
@@ -56,3 +56,17 @@ def test_auto_id():
         ],
     ).auto_panel_ids()
     assert dashboard.rows[0].panels[0].id == 1
+
+
+def test_row_show_title():
+    row = G.Row().to_json_data()
+    assert row['title'] == 'New row'
+    assert row['showTitle'] == False
+
+    row = G.Row(title='My title').to_json_data()
+    assert row['title'] == 'My title'
+    assert row['showTitle'] == True
+
+    row = G.Row(title='My title', showTitle=False).to_json_data()
+    assert row['title'] == 'My title'
+    assert row['showTitle'] == False


### PR DESCRIPTION
The `showTitle` option in `Row` is currently ignored and depends only on the `title` option.