### PR TITLE
Allow specifying a data source input

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -422,13 +422,9 @@ class Annotations(object):
 
 
 @attr.s
-class Input(object):
+class DataSourceInput(object):
     name = attr.ib()
     label = attr.ib()
-
-
-@attr.s
-class DataSourceInput(Input):
     pluginId = attr.ib()
     pluginName = attr.ib()
     description = attr.ib(default="", validator=instance_of(str))
@@ -445,7 +441,9 @@ class DataSourceInput(Input):
 
 
 @attr.s
-class ConstantInput(Input):
+class ConstantInput(object):
+    name = attr.ib()
+    label = attr.ib()
     value = attr.ib()
     description = attr.ib(default="", validator=instance_of(str))
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -414,6 +414,25 @@ class Annotations(object):
 
 
 @attr.s
+class DataSourceInput(object):
+    name = attr.ib()
+    type = attr.ib()
+    label = attr.ib()
+    pluginId = attr.ib()
+    pluginName = attr.ib()
+    description = attr.ib(default="", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+            "name": self.name,
+            "label": self.label,
+            "description": self.description,
+            "type": self.type,
+            "pluginId": self.pluginId,
+            "pluginName": self.pluginName
+        }
+
+@attr.s
 class DashboardLink(object):
     dashboard = attr.ib()
     uri = attr.ib()
@@ -691,6 +710,7 @@ class Dashboard(object):
         validator=instance_of(bool),
     )
     id = attr.ib(default=None)
+    inputs = attr.ib(default=attr.Factory(list))
     links = attr.ib(default=attr.Factory(list))
     refresh = attr.ib(default=DEFAULT_REFRESH)
     schemaVersion = attr.ib(default=SCHEMA_VERSION)
@@ -740,6 +760,7 @@ class Dashboard(object):
 
     def to_json_data(self):
         return {
+            '__inputs': self.inputs,
             'annotations': self.annotations,
             'editable': self.editable,
             'gnetId': self.gnetId,

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -133,6 +133,14 @@ TEXT_MODE_MARKDOWN = "markdown"
 TEXT_MODE_HTML = "html"
 TEXT_MODE_TEXT = "text"
 
+# Datasource plugins
+PLUGIN_ID_GRAPHITE = "graphite"
+PLUGIN_ID_PROMETHEUS = "prometheus"
+PLUGIN_ID_INFLUXDB = "influxdb"
+PLUGIN_ID_OPENTSDB = "opentsdb"
+PLUGIN_ID_ELASTICSEARCH = "elasticsearch"
+PLUGIN_ID_CLOUDWATCH = "cloudwatch"
+
 
 @attr.s
 class Mapping(object):
@@ -414,23 +422,42 @@ class Annotations(object):
 
 
 @attr.s
-class DataSourceInput(object):
+class Input(object):
     name = attr.ib()
-    type = attr.ib()
     label = attr.ib()
+
+
+@attr.s
+class DataSourceInput(Input):
     pluginId = attr.ib()
     pluginName = attr.ib()
     description = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
         return {
-            "name": self.name,
-            "label": self.label,
             "description": self.description,
-            "type": self.type,
+            "label": self.label,
+            "name": self.name,
             "pluginId": self.pluginId,
-            "pluginName": self.pluginName
+            "pluginName": self.pluginName,
+            "type": "datasource",
         }
+
+
+@attr.s
+class ConstantInput(Input):
+    value = attr.ib()
+    description = attr.ib(default="", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+            "description": self.description,
+            "label": self.label,
+            "name": self.name,
+            "type": "constant",
+            "value": self.value,
+        }
+
 
 @attr.s
 class DashboardLink(object):


### PR DESCRIPTION
* Allows creation of dashboards which parametrise the input datasource [1]

Python code
```
...
dashboard = Dashboard(
    inputs=[
        DataSourceInput(
            name="DS_PROMETHEUS",
            type="datasource",
            label="Prometheus",
            pluginId="prometheus",
            pluginName="Prometheus"
        )],
...
```

Generated JSON
```
...
  "__inputs": [
    {
      "description": "",
      "label": "Prometheus",
      "name": "DS_PROMETHEUS",
      "pluginId": "prometheus",
      "pluginName": "Prometheus",
      "type": "datasource"
    }
  ],
...
```

Python code
```
...
    inputs=[
        ConstantInput(
            name="VAR_PREFIX",
            label="prefix",
            value="collectd"
        ),
...
```

Generated JSON
```
...
  "__inputs": [
    {
      "description": "",
      "label": "prefix",
      "name": "VAR_PREFIX",
      "type": "constant",
      "value": "collectd"
    },
...
```


[1] http://docs.grafana.org/reference/export_import/