### PR TITLE
core: add nullPointMode NULL_AS_NULL

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -64,6 +64,7 @@ CUMULATIVE = 'cumulative'
 
 NULL_CONNECTED = 'connected'
 NULL_AS_ZERO = 'null as zero'
+NULL_AS_NULL = 'null'
 
 FLOT = 'flot'
 


### PR DESCRIPTION
A constant was missing to set the null point mode to null.
Add the constant NULL_AS_NULL for it.