### PR TITLE
Add support for Elasticsearch queries

### DIFF
--- a/docs/example-elasticsearch.dashboard.py
+++ b/docs/example-elasticsearch.dashboard.py
@@ -1,0 +1,65 @@
+from grafanalib.core import *
+from grafanalib.elasticsearch import *
+
+suc_label = "Success (1XX)"
+clt_err_label = "Client Errors (4XX)"
+resptime_label = "Max response time"
+
+filterSetting = FiltersAggSettings(filters=[
+        Filter(query="response: [200 TO 300]", label=suc_label),
+        Filter(query="response: [400 TO 500]", label=clt_err_label)])
+
+tgts = [ElasticsearchTarget(query='request: "/login"',
+                            bucket_aggs=[FiltersAgg(settings=filterSetting),
+                                         DateTimeAgg(settings=DateTimeAggSettings(interval="10m"))]),
+        ElasticsearchTarget(query='request: "/login"',
+                            metrics=[MaxMetric(field="resptime")],
+                            alias=resptime_label)]
+
+g = Graph(title="login requests",
+          dataSource="elasticsearch",
+          targets=tgts,
+          lines=False,
+          legend=Legend(alignAsTable=True, rightSide=True,
+                        total=True, current=True, max=True),
+          lineWidth=1,
+          nullPointMode=NULL_AS_NULL,
+          seriesOverrides=[{
+                            "alias": suc_label,
+                            "bars": True,
+                            "lines": False,
+                            "stack": "A",
+                            "yaxis": 1,
+                            "color": "#629E51"
+                           },
+                           {
+                            "alias": clt_err_label,
+                            "bars": True,
+                            "lines": False,
+                            "stack": "A",
+                            "yaxis": 1,
+                            "color": "#E5AC0E"
+                           },
+                           {
+                            "alias": resptime_label,
+                            "lines": True,
+                            "fill": 0,
+                            "nullPointMode": "connected",
+                            "steppedLine": True,
+                            "yaxis": 2,
+                            "color": "#447EBC"
+                           },
+                           ],
+          yAxes=[YAxis(label="Count",
+                       format=SHORT_FORMAT,
+                       decimals=0
+                       ),
+                 YAxis(label="Response Time",
+                       format=SECONDS_FORMAT,
+                       decimals=2)],
+                      transparent=True,
+          span=12,
+    )
+
+dashboard = Dashboard(title="HTTP dashboard",
+                      rows=[Row(panels=[g])])

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -1,0 +1,147 @@
+"""Support for Elasticsearch."""
+
+import attr
+import itertools
+import grafanalib.validators as validators
+from attr.validators import instance_of
+
+
+@attr.s
+class CountMetric(object):
+    field = attr.ib(default="select field", validator=instance_of(str))
+    type = attr.ib(default="count", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+            'field': self.field,
+            'type': self.type,
+        }
+
+
+@attr.s
+class MaxMetric(object):
+    field = attr.ib(default="select field", validator=instance_of(str))
+    type = attr.ib(default="max", validator=instance_of(str))
+    # without an empty settings key, it's not displayed correctly in the
+    # dashboard's "Metrics" view in the webinterface
+    settings = attr.ib(default=attr.Factory(dict))
+
+    def to_json_data(self):
+        return {
+            'field': self.field,
+            'type': self.type,
+            'settings': self.settings
+        }
+
+
+@attr.s
+class DateTimeAggSettings(object):
+    interval = attr.ib(default="auto", validator=instance_of(str))
+    min_doc_count = attr.ib(default=0, validator=instance_of(int))
+    trimEdges = attr.ib(default=0, validator=instance_of(int))
+
+    def to_json_data(self):
+        return {
+                'interval': self.interval,
+                'min_doc_count': self.min_doc_count,
+                'trimEdges': self.trimEdges,
+                }
+
+
+@attr.s
+class DateTimeAgg(object):
+    field = attr.ib(default="time_iso8601", validator=instance_of(str))
+    id = attr.ib(default=0, validator=instance_of(int))
+    settings = attr.ib(default=DateTimeAggSettings())
+    type = attr.ib(default="date_histogram", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+                'field': self.field,
+                'id': str(self.id),
+                'settings': self.settings,
+                'type': self.type
+                }
+
+
+@attr.s
+class Filter(object):
+    label = attr.ib(default="", validator=instance_of(str))
+    query = attr.ib(default="", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+                'label': self.label,
+                'query': self.query
+                }
+
+
+@attr.s
+class FiltersAggSettings(object):
+    filters = attr.ib(default=attr.Factory(list))
+
+    def to_json_data(self):
+        return {
+                'filters': self.filters
+               }
+
+
+@attr.s
+class FiltersAgg(object):
+    field = attr.ib(default="time_iso8601", validator=instance_of(str))
+    id = attr.ib(default=0, validator=instance_of(int))
+    settings = attr.ib(default=FiltersAggSettings())
+    type = attr.ib(default="filters", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+                'field': self.field,
+                'id': str(self.id),
+                'settings': self.settings,
+                'type': self.type
+                }
+
+
+@attr.s
+class ElasticsearchTarget(object):
+    """Generates Elasticsearch target JSON structure.
+
+    Grafana docs on using Elasticsearch:
+    http://docs.grafana.org/features/datasources/elasticsearch/
+    Elasticsearch docs on querying or reading data:
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+
+    :param alias: legend alias
+    :param bucketAggs: Group by query aggregators
+    :param metrics: Elasticsearch metric
+    :param query: query
+    :param refId: target reference id
+    """
+
+    alias = attr.ib(default=None)
+    bucket_aggs = attr.ib(default=[DateTimeAgg()])
+    metrics = attr.ib(default=[CountMetric()])
+    query = attr.ib(default="", validator=instance_of(str))
+    refId = attr.ib(default="", validator=instance_of(str))
+
+    def auto_bucket_aggs_id(self):
+        ids = set([agg.id for agg in self.bucket_aggs if agg.id])
+        auto_ids = (i for i in itertools.count(1) if i not in ids)
+
+        def set_id(agg):
+            if agg.id:
+                return agg
+
+            agg.id = next(auto_ids)
+            return agg
+
+        return list(map(set_id, self.bucket_aggs))
+
+    def to_json_data(self):
+        return {
+            'alias': self.alias,
+            'bucketAggs': self.auto_bucket_aggs_id(),
+            'metrics': self.metrics,
+            'query': self.query,
+            'refId': self.refId,
+        }

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -101,6 +101,30 @@ class FiltersAgg(object):
                 'type': self.type
                 }
 
+@attr.s
+class TermsAggSettings(object):
+    min_doc_count = attr.ib(default=1, validator=instance_of(int))
+    order = attr.ib(default="desc", validator=instance_of(str))
+    order_by = attr.ib(default="_term", validator=instance_of(str))
+    size = attr.ib(default=0, validator=instance_of(int))
+
+    def to_json_data(self):
+        pass
+
+@attr.s
+class TermsAgg(object):
+    field = attr.ib(validator=instance_of(str))
+    id = attr.ib(default=0, validator=instance_of(int))
+    settings = attr.ib(default=TermsAggSettings())
+    type = attr.ib(default="terms", validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+                'field': self.field,
+                'id': str(self.id),
+                'settings': self.settings,
+                'type': self.type
+                }
 
 @attr.s
 class ElasticsearchTarget(object):


### PR DESCRIPTION
The PR adds partial support for creating graphs containing Elasticsearch queries.
Grafana supports a lot more metrics and aggregators for elasticsearch that are not implemented in this PR.
They could be added as needed in following PRs.


I first used inheritance to define parent Metric and Aggregator classes that contain the shared attributes of the variants but I couldn't figure out how to make it work with the attrs lib.
I need to change the default values of some attributes of the parent class but still need to be able to accept alternative values for them in the constructor.
It doesn't work with `__attrs_post_init__ ()` because it runs after the constructor and then override the values that are passed to the constructor as parameter.
If I would use composition instead the same problem exist and it would make the classes more cumbersome to use.
I would appreciate suggestions how I  could outsource the common attributes and `to_json_data()` implementation of  the Metric and Aggregator classes when using the attrs lib.