### PR TITLE
templating: make setting label optional

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -513,9 +513,9 @@ class Template(object):
 
     default = attr.ib()
     dataSource = attr.ib()
-    label = attr.ib()
     name = attr.ib()
     query = attr.ib()
+    label = attr.ib(default=None)
     allValue = attr.ib(default=None)
     includeAll = attr.ib(
         default=False,


### PR DESCRIPTION
grafanalib required that a value for the label attribute of a Template
is set.
The grafana GUI does not require to set a label. If none is set, the
attributes value is null and the Name of the template variable is used
as label.

Use the same approach in grafanalib, set the default value to None.

The attribute needed to be moved down because of the following attrs exception:
  ValueError: No mandatory attributes allowed after an attribute with a default
  value or factory.  Attribute in question: Attribute(name='name',
  [..]