### PR TITLE
Templating: Allow to use groups/tags

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -528,6 +528,12 @@ class Template(object):
         validator=instance_of(bool),
     )
     regex = attr.ib(default=None)
+    useTags = attr.ib(
+        default=False,
+        validator=instance_of(bool),
+    )
+    tagsQuery = attr.ib(default=None)
+    tagValuesQuery = attr.ib(default=None)
 
     def to_json_data(self):
         return {
@@ -548,9 +554,10 @@ class Template(object):
             'refresh': 1,
             'regex': self.regex,
             'sort': 1,
-            'tagValuesQuery': None,
-            'tagsQuery': None,
             'type': 'query',
+            'useTags': self.useTags,
+            'tagsQuery': self.tagsQuery,
+            'tagValuesQuery': self.tagValuesQuery,
         }
 
 


### PR DESCRIPTION
Provide : http://docs.grafana.org/reference/templating/#value-groups-tags

Change the static `None` value to be part of the attribute list of `Template` class.

This commit provide `useTags`, `tagsQuery`, `tagValuesQuery` attribute on
`Template`