### PR TITLE
Replace `SourceFileLoader` with python2 style `imp.load_source`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 machine:
   services:
     - docker
-  python:
-    version: 3.5.2
+  post:
+    - pyenv global 2.7.12 3.4.4 3.5.2
   environment:
     PATH: $HOME/bin:$PATH
     SRCDIR: /home/ubuntu/src/github.com/weaveworks/grafanalib

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   post:
-    - pyenv global 2.7.12 3.4.4 3.5.2
+    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.4
   environment:
     PATH: $HOME/bin:$PATH
     SRCDIR: /home/ubuntu/src/github.com/weaveworks/grafanalib

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   post:
-    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.4
+    - pyenv global 2.7.12 3.4.4 3.5.2 3.6.1
   environment:
     PATH: $HOME/bin:$PATH
     SRCDIR: /home/ubuntu/src/github.com/weaveworks/grafanalib

--- a/grafanalib/_gen.py
+++ b/grafanalib/_gen.py
@@ -1,10 +1,10 @@
 """Generate JSON Grafana dashboards."""
 
 import argparse
+import imp
 import json
 import os
 import sys
-from importlib.machinery import SourceFileLoader
 
 
 DASHBOARD_SUFFIX = '.dashboard.py'
@@ -21,7 +21,7 @@ def load_dashboard(path):
         ``dashboard``.
     :return: A ``Dashboard``
     """
-    module = SourceFileLoader("dashboard", path).load_module()
+    module = imp.load_source("dashboard", path)
     marker = object()
     dashboard = getattr(module, 'dashboard', marker)
     if dashboard is marker:

--- a/grafanalib/tests/test_grafanalib.py
+++ b/grafanalib/tests/test_grafanalib.py
@@ -1,9 +1,13 @@
 """Tests for Grafanalib."""
 
-from io import StringIO
-
 import grafanalib.core as G
 from grafanalib import _gen
+
+import sys
+if sys.version_info[0] < 3:
+    from io import BytesIO as StringIO
+else:
+    from io import StringIO
 
 # TODO: Use Hypothesis to generate a more thorough battery of smoke tests.
 

--- a/grafanalib/tests/test_opentsdb.py
+++ b/grafanalib/tests/test_opentsdb.py
@@ -1,17 +1,17 @@
 """Tests for OpenTSDB datasource"""
 
-import sys
-if sys.version_info[0] < 3:
-    from io import BytesIO as StringIO
-else:
-    from io import StringIO
-
 import grafanalib.core as G
 from grafanalib.opentsdb import (
     OpenTSDBFilter,
     OpenTSDBTarget,
 )
 from grafanalib import _gen
+
+import sys
+if sys.version_info[0] < 3:
+    from io import BytesIO as StringIO
+else:
+    from io import StringIO
 
 
 def test_serialization_opentsdb_target():

--- a/grafanalib/tests/test_opentsdb.py
+++ b/grafanalib/tests/test_opentsdb.py
@@ -1,6 +1,10 @@
 """Tests for OpenTSDB datasource"""
 
-from io import StringIO
+import sys
+if sys.version_info[0] < 3:
+    from io import BytesIO as StringIO
+else:
+    from io import StringIO
 
 import grafanalib.core as G
 from grafanalib.opentsdb import (

--- a/grafanalib/tests/test_zabbix.py
+++ b/grafanalib/tests/test_zabbix.py
@@ -1,6 +1,10 @@
 """Tests for Zabbix Datasource"""
 
-from io import StringIO
+import sys
+if sys.version_info[0] < 3:
+    from io import BytesIO as StringIO
+else:
+    from io import StringIO
 
 import grafanalib.core as G
 import grafanalib.zabbix as Z

--- a/grafanalib/tests/test_zabbix.py
+++ b/grafanalib/tests/test_zabbix.py
@@ -1,14 +1,14 @@
 """Tests for Zabbix Datasource"""
 
+import grafanalib.core as G
+import grafanalib.zabbix as Z
+from grafanalib import _gen
+
 import sys
 if sys.version_info[0] < 3:
     from io import BytesIO as StringIO
 else:
     from io import StringIO
-
-import grafanalib.core as G
-import grafanalib.zabbix as Z
-from grafanalib import _gen
 
 
 def test_serialization_zabbix_target():


### PR DESCRIPTION
Normally this commit adds python2 support for grafanalib which is
required to work with grafanalib right from `bazel`.

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
This commit replaces python3-only way of `importlib.machinery.SourceFileLoader` for dashboards with more generic `imp.load_source` available widely in python2 and python3.

## Why is it a good idea?
This will help to create grafanalib rules for bazel to build dashboards right there without any strange behaviour of various python versions required for particular bazel rules and grafanalib. It will work simply on every python in fact without any impact to announced support for python 3.4 and 3.5.

## Context
Some links about bazel:
 - https://www.bazel.build
 - https://github.com/bazelbuild/rules_python

Some bazel rules like docker ones are written on python and running bazel with specified python version only doesn't work properly since forces all the staff to use the only python which causes break for third-party rules.

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->