### PR TITLE
Generate test coverage report in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+include =
+    grafanalib/*.py
+    grafanalib/**/*.py

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 /.cache
 .ensure-*
 /.tox
+/.coverage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean clean-deps lint test deps
+.PHONY: all clean clean-deps lint test deps coverage
 .DEFAULT_GOAL := all
 
 # Boiler plate for bulding Docker containers.
@@ -51,7 +51,7 @@ endif
 images:
 	$(info $(IMAGE_NAMES))
 
-all: $(UPTODATE_FILES) test lint
+all: $(UPTODATE_FILES) test lint coverage
 
 deps: setup.py .ensure-tox tox.ini
 
@@ -64,6 +64,9 @@ lint: .ensure-flake8
 
 test: .ensure-tox
 	$(TOX) --skip-missing-interpreters
+
+coverage:
+	$(TOX) -e coverage
 
 clean:
 	$(SUDO) docker rmi $(IMAGE_NAMES) >/dev/null 2>&1 || true

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,13 @@ envlist = py27, py34, py35, py36
 commands = pytest --junitxml=junit-{envname}.xml
 deps =
     pytest
+
+[testenv:coverage]
+deps =
+    coverage
+    pytest
+commands =
+    python -m coverage run --rcfile=.coveragerc -m pytest --strict --maxfail=1 --ff {posargs}
+    # Had 88% test coverage at time of introducing coverage ratchet.
+    # This number must only go up.
+    python -m coverage report --rcfile=.coveragerc --show-missing --fail-under=88


### PR DESCRIPTION
Fail if our test coverage goes down.

## What does this do?

Adjusts our CI so that we generate test coverage data and fail if it goes below 88%.

## Why is it a good idea?

We really want 100% test coverage, but the first step is to ensure that it doesn't go lower. Test coverage is good because it catches bugs.

## Context

I'd like to do coveralls or something, but that's for later. 