### PR TITLE
Use attr.Factory for all "mutable" defaults

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -197,9 +197,15 @@ VTYPE_DEFAULT = VTYPE_AVG
 class Grid(object):
 
     threshold1 = attr.ib(default=None)
-    threshold1Color = attr.ib(default=GREY1, validator=instance_of(RGBA))
+    threshold1Color = attr.ib(
+        default=attr.Factory(lambda: GREY1),
+        validator=instance_of(RGBA),
+    )
     threshold2 = attr.ib(default=None)
-    threshold2Color = attr.ib(default=GREY2, validator=instance_of(RGBA))
+    threshold2Color = attr.ib(
+        default=attr.Factory(lambda: GREY2),
+        validator=instance_of(RGBA),
+    )
 
     def to_json_data(self):
         return {
@@ -414,7 +420,10 @@ class Row(object):
     editable = attr.ib(
         default=True, validator=instance_of(bool),
     )
-    height = attr.ib(default=DEFAULT_ROW_HEIGHT, validator=instance_of(Pixels))
+    height = attr.ib(
+        default=attr.Factory(lambda: DEFAULT_ROW_HEIGHT),
+        validator=instance_of(Pixels),
+    )
     showTitle = attr.ib(default=None)
     title = attr.ib(default=None)
     repeat = attr.ib(default=None)
@@ -773,7 +782,7 @@ class Dashboard(object):
     title = attr.ib()
     rows = attr.ib()
     annotations = attr.ib(
-        default=Annotations(),
+        default=attr.Factory(Annotations),
         validator=instance_of(Annotations),
     )
     editable = attr.ib(
@@ -797,15 +806,15 @@ class Dashboard(object):
     style = attr.ib(default=DARK_STYLE)
     tags = attr.ib(default=attr.Factory(list))
     templating = attr.ib(
-        default=Templating(),
+        default=attr.Factory(Templating),
         validator=instance_of(Templating),
     )
     time = attr.ib(
-        default=DEFAULT_TIME,
+        default=attr.Factory(lambda: DEFAULT_TIME),
         validator=instance_of(Time),
     )
     timePicker = attr.ib(
-        default=DEFAULT_TIME_PICKER,
+        default=attr.Factory(lambda: DEFAULT_TIME_PICKER),
         validator=instance_of(TimePicker),
     )
     timezone = attr.ib(default=UTC)
@@ -947,9 +956,15 @@ class Graph(object):
 
 @attr.s
 class SparkLine(object):
-    fillColor = attr.ib(default=BLUE_RGBA, validator=instance_of(RGBA))
+    fillColor = attr.ib(
+        default=attr.Factory(lambda: BLUE_RGBA),
+        validator=instance_of(RGBA),
+    )
     full = attr.ib(default=False, validator=instance_of(bool))
-    lineColor = attr.ib(default=BLUE_RGB, validator=instance_of(RGB))
+    lineColor = attr.ib(
+        default=attr.Factory(BLUE_RGB),
+        validator=instance_of(RGB),
+    )
     show = attr.ib(default=False, validator=instance_of(bool))
 
     def to_json_data(self):
@@ -1095,7 +1110,7 @@ class SingleStat(object):
     targets = attr.ib()
     title = attr.ib()
     cacheTimeout = attr.ib(default=None)
-    colors = attr.ib(default=[GREEN, ORANGE, RED])
+    colors = attr.ib(default=attr.Factory(lambda: [GREEN, ORANGE, RED]))
     colorBackground = attr.ib(default=False, validator=instance_of(bool))
     colorValue = attr.ib(default=False, validator=instance_of(bool))
     description = attr.ib(default=None)
@@ -1110,8 +1125,12 @@ class SingleStat(object):
     interval = attr.ib(default=None)
     links = attr.ib(default=attr.Factory(list))
     mappingType = attr.ib(default=MAPPING_TYPE_VALUE_TO_TEXT)
-    mappingTypes = attr.ib(default=[MAPPING_VALUE_TO_TEXT,
-                                    MAPPING_RANGE_TO_TEXT])
+    mappingTypes = attr.ib(
+        default=attr.Factory(lambda: [
+            MAPPING_VALUE_TO_TEXT,
+            MAPPING_RANGE_TO_TEXT,
+        ]),
+    )
     maxDataPoints = attr.ib(default=100)
     minSpan = attr.ib(default=None)
     nullText = attr.ib(default=None)
@@ -1123,8 +1142,10 @@ class SingleStat(object):
     rangeMaps = attr.ib(default=attr.Factory(list))
     repeat = attr.ib(default=None)
     span = attr.ib(default=6)
-    sparkline = attr.ib(default=attr.Factory(SparkLine),
-                        validator=instance_of(SparkLine))
+    sparkline = attr.ib(
+        default=attr.Factory(SparkLine),
+        validator=instance_of(SparkLine),
+    )
     thresholds = attr.ib(default="")
     transparent = attr.ib(default=False, validator=instance_of(bool))
     valueFontSize = attr.ib(default="80%")

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -56,22 +56,24 @@ class DateHistogramGroupBy(object):
                         result
     """
     id = attr.ib(default=0, validator=instance_of(int))
-    field = attr.ib(default=DATE_HISTOGRAM_DEFAULT_FIELD,
-                    validator=instance_of(str))
+    field = attr.ib(
+        default=DATE_HISTOGRAM_DEFAULT_FIELD,
+        validator=instance_of(str),
+    )
     interval = attr.ib(default="auto", validator=instance_of(str))
     minDocCount = attr.ib(default=0, validator=instance_of(int))
 
     def to_json_data(self):
         return {
-                'field': self.field,
-                'id': str(self.id),
-                'settings': {
-                             'interval': self.interval,
-                             'min_doc_count': self.minDocCount,
-                             'trimEdges': 0,
-                             },
-                'type': 'date_histogram',
-                }
+            'field': self.field,
+            'id': str(self.id),
+            'settings': {
+                'interval': self.interval,
+                'min_doc_count': self.minDocCount,
+                'trimEdges': 0,
+            },
+            'type': 'date_histogram',
+        }
 
 
 @attr.s
@@ -137,16 +139,16 @@ class TermsGroupBy(object):
 
     def to_json_data(self):
         return {
-                'id': str(self.id),
-                'type': 'terms',
-                'field': self.field,
-                'settings': {
-                    'min_doc_count': self.minDocCount,
-                    'order': self.order,
-                    'order_by': self.orderBy,
-                    'size': self.size,
-                 },
-                }
+            'id': str(self.id),
+            'type': 'terms',
+            'field': self.field,
+            'settings': {
+                'min_doc_count': self.minDocCount,
+                'order': self.order,
+                'order_by': self.orderBy,
+                'size': self.size,
+            },
+        }
 
 
 @attr.s
@@ -166,8 +168,9 @@ class ElasticsearchTarget(object):
     """
 
     alias = attr.ib(default=None)
-    bucketAggs = attr.ib(default=attr.Factory(
-                                          lambda: [DateHistogramGroupBy()]))
+    bucketAggs = attr.ib(
+        default=attr.Factory(lambda: [DateHistogramGroupBy()]),
+    )
     metricAggs = attr.ib(default=attr.Factory(lambda: [CountMetricAgg()]))
     query = attr.ib(default="", validator=instance_of(str))
     refId = attr.ib(default="", validator=instance_of(str))

--- a/grafanalib/zabbix.py
+++ b/grafanalib/zabbix.py
@@ -31,7 +31,8 @@ ZABBIX_SLA_PROP_PROBTIME = {
 
 ZABBIX_SLA_PROP_DOWNTIME = {
     "name": "Down time",
-    "property": "downtimeTime"}
+    "property": "downtimeTime",
+}
 
 ZABBIX_EVENT_PROBLEMS = {
     "text": "Problems",
@@ -51,10 +52,12 @@ ZABBIX_TRIGGERS_SHOW_NACK = "unacknowledged"
 
 ZABBIX_SORT_TRIGGERS_BY_CHANGE = {
     "text": "last change",
-    "value": "lastchange"}
+    "value": "lastchange",
+}
 ZABBIX_SORT_TRIGGERS_BY_SEVERITY = {
     "text": "severity",
-    "value": "priority"}
+    "value": "priority",
+}
 
 ZABBIX_SEVERITY_COLORS = (
     ("#B7DBAB", "Not classified"),
@@ -62,7 +65,8 @@ ZABBIX_SEVERITY_COLORS = (
     ("#E5AC0E", "Warning"),
     ("#C15C17", "Average"),
     ("#BF1B00", "High"),
-    ("#890F02", "Disaster"))
+    ("#890F02", "Disaster"),
+)
 
 
 def convertZabbixSeverityColors(colors):
@@ -778,7 +782,7 @@ class ZabbixTriggersPanel(object):
     dataSource = attr.ib()
     title = attr.ib()
 
-    ackEventColor = attr.ib(default=BLANK,
+    ackEventColor = attr.ib(default=attr.Factory(lambda: BLANK),
                             validator=instance_of(RGBA))
     ageField = attr.ib(default=True, validator=instance_of(bool))
     customLastChangeFormat = attr.ib(default=False,
@@ -801,23 +805,28 @@ class ZabbixTriggersPanel(object):
                     validator=is_list_of(DashboardLink))
     markAckEvents = attr.ib(default=False, validator=instance_of(bool))
     minSpan = attr.ib(default=None)
-    okEventColor = attr.ib(default=GREEN,
+    okEventColor = attr.ib(default=attr.Factory(lambda: GREEN),
                            validator=instance_of(RGBA))
     pageSize = attr.ib(default=10, validator=instance_of(int))
     repeat = attr.ib(default=None)
     scroll = attr.ib(default=True, validator=instance_of(bool))
     severityField = attr.ib(default=False, validator=instance_of(bool))
-    showEvents = attr.ib(default=ZABBIX_EVENT_PROBLEMS)
+    showEvents = attr.ib(default=attr.Factory(lambda: ZABBIX_EVENT_PROBLEMS))
     showTriggers = attr.ib(default=ZABBIX_TRIGGERS_SHOW_ALL)
-    sortTriggersBy = attr.ib(default=ZABBIX_SORT_TRIGGERS_BY_CHANGE)
+    sortTriggersBy = attr.ib(
+        default=attr.Factory(lambda: ZABBIX_SORT_TRIGGERS_BY_CHANGE),
+    )
     span = attr.ib(default=None)
     statusField = attr.ib(default=False, validator=instance_of(bool))
     transparent = attr.ib(default=False, validator=instance_of(bool))
     triggerSeverity = attr.ib(
         default=ZABBIX_SEVERITY_COLORS,
-        convert=convertZabbixSeverityColors)
-    triggers = attr.ib(default=ZabbixTrigger(),
-                       validator=instance_of(ZabbixTrigger))
+        convert=convertZabbixSeverityColors,
+    )
+    triggers = attr.ib(
+        default=attr.Factory(ZabbixTrigger),
+        validator=instance_of(ZabbixTrigger),
+    )
 
     def to_json_data(self):
         return {


### PR DESCRIPTION
Fixes #105, preventing a class of unlikely by nasty bugs (see [Python gotchas](http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments))

## What does this do?

Ensures that any default attribute values which are of mutable type are constructed with `attr.Factory`, to prevent accidental re-use.

## Why is it a good idea?

If someone does mutate these values (not recommended) they will see weird and hard-to-predict behaviour.

