### PR TITLE
bugfix: SparkLine __init__  error.

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -962,7 +962,7 @@ class SparkLine(object):
     )
     full = attr.ib(default=False, validator=instance_of(bool))
     lineColor = attr.ib(
-        default=attr.Factory(BLUE_RGB),
+        default=attr.Factory(lambda: BLUE_RGB),
         validator=instance_of(RGB),
     )
     show = attr.ib(default=False, validator=instance_of(bool))


### PR DESCRIPTION
SparkLine use BLUE_RGB as a function, which will lead to `TypeError: 'RGB' object is not callable` error.