### PR TITLE
Fix crasher bug in `SingleStat`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+0.5.1 (2018-02-27)
+==================
+
+Fixes
+-----
+
+* Fix for crasher bug that broke ``SingleStat``, introduced by `#114`_
+
+.. _`#114`: https://github.com/weaveworks/grafanalib/pull/114
+
+
 0.5.0 (2018-02-26)
 ==================
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -962,7 +962,7 @@ class SparkLine(object):
     )
     full = attr.ib(default=False, validator=instance_of(bool))
     lineColor = attr.ib(
-        default=attr.Factory(BLUE_RGB),
+        default=attr.Factory(lambda: BLUE_RGB),
         validator=instance_of(RGB),
     )
     show = attr.ib(default=False, validator=instance_of(bool))
@@ -1056,12 +1056,12 @@ class Text(object):
 
 @attr.s
 class SingleStat(object):
-    """Generates Signle Stat panel json structure
+    """Generates Single Stat panel json structure
 
     Grafana doc on singlestat: http://docs.grafana.org/reference/singlestat/
 
     :param dataSource: Grafana datasource name
-    :param targets: list of metric requests for chousen datasource
+    :param targets: list of metric requests for chosen datasource
     :param title: panel title
     :param cacheTimeout: metric query result cache ttl
     :param colors: the list of colors that can be used for coloring

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -22,3 +22,14 @@ def test_table_styled_columns():
     assert t.styles == [
         G.ColumnStyle(pattern='Foo'),
     ]
+
+
+def test_single_stat():
+    data_source = 'dummy data source'
+    targets = ['dummy_prom_query']
+    title = 'dummy title'
+    single_stat = G.SingleStat(data_source, targets, title)
+    data = single_stat.to_json_data()
+    assert data['targets'] == targets
+    assert data['datasource'] == data_source
+    assert data['title'] == title


### PR DESCRIPTION
## What does this do?

Updates a default in `SparkLine` to correctly return a colour, rather than try to call the colour.

## Why is it a good idea?

Without this, you cannot construct `SparkLine` or `SingleStat`

## Context

Original fix is in #116, courtesy @xxr3376. This adds tests and changelog update.
