### PR TITLE
Add 'uid' parameter to Dashboards for stable grafana URLs

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -839,6 +839,7 @@ class Dashboard(object):
     )
     timezone = attr.ib(default=UTC)
     version = attr.ib(default=0)
+    uid = attr.ib(default=None)
 
     def _iter_panels(self):
         for row in self.rows:
@@ -884,6 +885,7 @@ class Dashboard(object):
             'timepicker': self.timePicker,
             'timezone': self.timezone,
             'version': self.version,
+            'uid': self.uid,
         }
 
 


### PR DESCRIPTION
## What does this do?
Allows the UID option to be set on dashboards.

## Why is it a good idea?
It allows graphs imported with Grafana 5 provisioners have stable URLs - stable across re-provisionings and dashboard renames.
See https://github.com/grafana/grafana/issues/11013

## Questions
We could generate a uid by hashing the dashboard name, if it were missing, but I wasn't sure if that was a great idea.

Towards https://github.com/weaveworks/grafanalib/issues/123