### PR TITLE
Template: add refresh arg.

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -177,6 +177,11 @@ SORT_ASC = 1
 SORT_DESC = 2
 SORT_IMPORTANCE = 3
 
+# Template
+REFRESH_NEVER = 0
+REFRESH_ON_DASHBOARD_LOAD = 1
+REFRESH_ON_TIME_RANGE_CHANGE = 2
+
 
 @attr.s
 class Mapping(object):
@@ -552,6 +557,7 @@ class Template(object):
         :param label: the variable's human label
         :param name: the variable's name
         :param query: the query users to fetch the valid values of the variable
+        :param refresh: Controls when to update values in the dropdown
         :param allValue: specify a custom all value with regex,
             globs or lucene syntax.
         :param includeAll: Add a special All option whose value includes
@@ -583,6 +589,8 @@ class Template(object):
     )
     tagsQuery = attr.ib(default=None)
     tagValuesQuery = attr.ib(default=None)
+    refresh = attr.ib(default=REFRESH_ON_DASHBOARD_LOAD,
+                      validator=instance_of(int))
 
     def to_json_data(self):
         return {
@@ -600,7 +608,7 @@ class Template(object):
             'name': self.name,
             'options': [],
             'query': self.query,
-            'refresh': 1,
+            'refresh': self.refresh,
             'regex': self.regex,
             'sort': 1,
             'type': 'query',


### PR DESCRIPTION
Allow to specify the refresh behavior of the template.

  * On Dashboard Load
  * On Time Range Change

Ref : http://docs.grafana.org/reference/templating/#query-options

>Controls when to update the variable option list (values in the dropdown). On Dashboard Load will slow down dashboard load as the variable query needs to be completed before dashboard can be initialized. Set this only to On Time Range Change if your variable options query contains a time range filter or is dependent on dashboard time range.
