### PR TITLE
Add org.opencontainers.image.* labels to Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX := quay.io/weaveworks
 IMAGE_TAG := $(shell ./tools/image-tag)
+GIT_REVISION := $(shell git rev-parse HEAD)
 UPTODATE := .uptodate
 
 # Building Docker images is now automated. The convention is every directory
@@ -12,7 +13,7 @@ UPTODATE := .uptodate
 # Dependencies (i.e. things that go in the image) still need to be explicitly
 # declared.
 %/$(UPTODATE): %/Dockerfile
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/$(shell basename $(@D)) $(@D)/
+	$(SUDO) docker build --build-arg=revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)/$(shell basename $(@D)) $(@D)/
 	$(SUDO) docker tag $(IMAGE_PREFIX)/$(shell basename $(@D)) $(IMAGE_PREFIX)/$(shell basename $(@D)):$(IMAGE_TAG)
 	touch $@
 

--- a/gfdatasource/Dockerfile
+++ b/gfdatasource/Dockerfile
@@ -1,8 +1,15 @@
 FROM alpine:3.6
-LABEL works.weave.role=system
 RUN apk add --no-cache --upgrade python3
 RUN python3 -m ensurepip && pip3 install --upgrade pip
 COPY requirements.txt /
 RUN pip3 install -r requirements.txt
 COPY gfdatasource /
 ENTRYPOINT ["/gfdatasource"]
+
+ARG revision
+LABEL works.weave.role="system" \
+      maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="grafanalib" \
+      org.opencontainers.image.source="https://github.com/weaveworks/grafanalib" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- `MAINTAINER` is deprecated, in favour of the `maintainer` label.
- Git revision (`git rev-parse HEAD`) is now injected at `docker build` time.

Testing
```console
$ docker inspect quay.io/weaveworks/gfdatasource
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "c7bcf1cfa3f5b754afb27ae732efe576d9cca467",
                "org.opencontainers.image.source": "https://github.com/weaveworks/grafanalib",
                "org.opencontainers.image.title": "grafanalib",
                "org.opencontainers.image.vendor": "Weaveworks",
                "works.weave.role": "system"
            }
[...]
```
