### PR TITLE
Fix missing legends in PromGraph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Changes
 -------
 
+* Fixed a bug that was losing any legends on a PromGraph
 * Added the AlertList Panel support in grafanalib/core
 * Added the support for mixed data sources  
 

--- a/grafanalib/prometheus.py
+++ b/grafanalib/prometheus.py
@@ -28,7 +28,7 @@ def PromGraph(data_source, title, expressions, **kwargs):
             for (args, refId) in zip(expressions, letters)]
     else:
         targets = [
-            G.Target(expr, legend, refId=refId)
+            G.Target(expr=expr, legendFormat=legend, refId=refId)
             for ((legend, expr), refId) in zip(expressions, letters)]
     return G.Graph(
         title=title,


### PR DESCRIPTION
Fix the bug whereby all legends are missing from `PromGraph` panels.

The bug was caused by `legendFormat` moving from the 2nd to 3rd positional parameter of `Graph`.
So I just named all the parameters to avoid hitting this again.
