### PR TITLE
Add `ExternalLink` class for dashboard-level links to other pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changes
 * Fixed a bug that was losing any legends on a PromGraph
 * Added the AlertList Panel support in grafanalib/core
 * Added the support for mixed data sources  
+* Add `ExternalLink` class for dashboard-level links to other pages
 
 
 0.5.2 (unreleased)

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -550,6 +550,31 @@ class DashboardLink(object):
 
 
 @attr.s
+class ExternalLink(object):
+    '''ExternalLink creates a top-level link attached to a dashboard.
+
+        :param url: the URL to link to
+        :param title: the text of the link
+        :param keepTime: if true, the URL params for the dashboard's
+            current time period are appended
+    '''
+    uri = attr.ib()
+    title = attr.ib()
+    keepTime = attr.ib(
+        default=False,
+        validator=instance_of(bool),
+    )
+
+    def to_json_data(self):
+        return {
+            "keepTime": self.keepTime,
+            "title": self.title,
+            "type": 'link',
+            "url": self.uri,
+        }
+
+
+@attr.s
 class Template(object):
     """Template create a new 'variable' for the dashboard, defines the variable
     name, human name, query to fetch the values and the default value.


### PR DESCRIPTION
## What does this do?
Adds support like `DashboardLink` but for links to other URLs

## Why is it a good idea?
for parity with the grafana editor