### PR TITLE
core: add type to Template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ Changes
 
 * Fixed a bug that was losing any legends on a PromGraph
 * Added the AlertList Panel support in grafanalib/core
-* Added the support for mixed data sources  
+* Added the support for mixed data sources
+* Template now supports 'type' attribute
 
 
 0.5.2 (unreleased)

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -567,6 +567,8 @@ class Template(object):
             return by your data source query.
         :param multi: If enabled, the variable will support the selection of
             multiple options at the same time.
+        :param type: The template type, can be one of: query (default),
+            interval, datasource, custom, constant, adhoc.
     """
 
     name = attr.ib()
@@ -590,6 +592,7 @@ class Template(object):
     )
     tagsQuery = attr.ib(default=None)
     tagValuesQuery = attr.ib(default=None)
+    type = attr.ib(default='query')
 
     def to_json_data(self):
         return {
@@ -610,7 +613,7 @@ class Template(object):
             'refresh': 1,
             'regex': self.regex,
             'sort': 1,
-            'type': 'query',
+            'type': self.type,
             'useTags': self.useTags,
             'tagsQuery': self.tagsQuery,
             'tagValuesQuery': self.tagValuesQuery,


### PR DESCRIPTION
My use case for this is dashboards where the datasource is a templating
variable, thus needing to specify type in Template.
