### PR TITLE
Add support for custom variables

### DIFF
--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -3,6 +3,61 @@
 import grafanalib.core as G
 
 
+def test_template_defaults():
+    t = G.Template(
+        name='test',
+        query='1m,5m,10m,30m,1h,3h,12h,1d',
+        type='interval',
+        default='1m',
+    )
+
+    assert t.to_json_data()['current']['text'] == '1m'
+    assert t.to_json_data()['current']['value'] == '1m'
+
+
+def test_custom_template_ok():
+    t = G.Template(
+        name='test',
+        query='1,2,3',
+        default='1',
+        type='custom',
+    )
+
+    assert len(t.to_json_data()['options']) == 3
+    assert t.to_json_data()['current']['text'] == '1'
+    assert t.to_json_data()['current']['value'] == '1'
+
+
+def test_custom_template_dont_override_options():
+    t = G.Template(
+        name='test',
+        query='1,2,3',
+        default='1',
+        options=[
+            {
+                "value": '1',
+                "selected": True,
+                "text": 'some text 1',
+            },
+            {
+                "value": '2',
+                "selected": False,
+                "text": 'some text 2',
+            },
+            {
+                "value": '3',
+                "selected": False,
+                "text": 'some text 3',
+            },
+        ],
+        type='custom',
+    )
+
+    assert len(t.to_json_data()['options']) == 3
+    assert t.to_json_data()['current']['text'] == 'some text 1'
+    assert t.to_json_data()['current']['value'] == '1'
+
+
 def test_table_styled_columns():
     t = G.Table.with_styled_columns(
         columns=[


### PR DESCRIPTION
## What does this do?
Provides proper support for custom template variables

## Why is it a good idea?
Currently custom variables must be manually updated in dashboard settings after import. If you choose a variable in grafana you will see something like that:
![image](https://user-images.githubusercontent.com/3119969/45562648-a54ec780-b853-11e8-9102-73cd94d99c00.png)

After this PR it won't be needed. This was tested on grafana 5.1 and 5.2.
This feature respects custom defined options so if they were provided explicitly they will be preferably used. This allows to add some human-readable definition of values (see how it's done in test):
![image](https://user-images.githubusercontent.com/3119969/45562457-32dde780-b853-11e8-97cf-a15047d97af3.png)


## Questions
I'm not an expert in `attrs` and I put my logic in `__attrs_post_init__()`. I'm not sure if this is a proper place for such logic, please comment here.
I preserved backwards-compatibilty and still take `query` parameter as is. However it be constructed from options if they are provided: I'm not sure about this.