### PR TITLE
add `Graph#auto_ref_ids`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ TBA
 * Add ``PieChart`` class for creating Pie Chart panels
 * Add `transparent` setting to classes that were missing it (Heatmap, PieChart)
 * Add InfluxDB data source
+* Add ``auto_ref_ids`` to ``Graph``s
 * ...
 
 

--- a/grafanalib/tests/test_grafanalib.py
+++ b/grafanalib/tests/test_grafanalib.py
@@ -62,6 +62,64 @@ def test_auto_id():
     assert dashboard.rows[0].panels[0].id == 1
 
 
+def test_auto_refids_preserves_provided_ids():
+    """
+    auto_ref_ids() provides refIds for all targets without refIds already
+    set.
+    """
+    dashboard = G.Dashboard(
+        title="Test dashboard",
+        rows=[
+            G.Row(panels=[
+                G.Graph(
+                    title="CPU Usage by Namespace (rate[5m])",
+                    targets=[
+                        G.Target(
+                            expr='whatever #Q',
+                            legendFormat='{{namespace}}',
+                        ),
+                        G.Target(
+                            expr='hidden whatever',
+                            legendFormat='{{namespace}}',
+                            refId='Q',
+                        ),
+                        G.Target(
+                            expr='another target'
+                        ),
+                    ],
+                ).auto_ref_ids()
+            ]),
+        ],
+    )
+    assert dashboard.rows[0].panels[0].targets[0].refId == 'A'
+    assert dashboard.rows[0].panels[0].targets[1].refId == 'Q'
+    assert dashboard.rows[0].panels[0].targets[2].refId == 'B'
+
+
+def test_auto_refids():
+    """
+    auto_ref_ids() provides refIds for all targets without refIds already
+    set.
+    """
+    dashboard = G.Dashboard(
+        title="Test dashboard",
+        rows=[
+            G.Row(panels=[
+                G.Graph(
+                    title="CPU Usage by Namespace (rate[5m])",
+                    targets=[G.Target(expr="metric %d" % i)
+                             for i in range(53)],
+                ).auto_ref_ids()
+            ]),
+        ],
+    )
+    assert dashboard.rows[0].panels[0].targets[0].refId == 'A'
+    assert dashboard.rows[0].panels[0].targets[25].refId == 'Z'
+    assert dashboard.rows[0].panels[0].targets[26].refId == 'AA'
+    assert dashboard.rows[0].panels[0].targets[51].refId == 'AZ'
+    assert dashboard.rows[0].panels[0].targets[52].refId == 'BA'
+
+
 def test_row_show_title():
     row = G.Row().to_json_data()
     assert row['title'] == 'New row'


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Adds a `#auto_ref_ids` method to Graph to add `refId` values for those `Target`s which do not have explicit `refId`s set, and preserves the IDs which are specified.  Its implementation is based on `Dashboard`'s `#auto_panel_ids` method.
<!-- brief explanation of the functionality this provides -->

## Why is it a good idea?
It is requested in #128 and reduces toil for Dashboard creators and maintainers.
<!-- how does it help grafanalib users / maintainers? -->

## Context
Any target list must have explicit `refId` attributes set today to make Grafana happy.  This is often an "auto-incrementing" alphabetical ID manually maintained by the creator of a dashboard.  This is only useful when one `Target` actually references another one - in other cases it is only toil.  I would like to reduce that toil.
<!-- any background that might help the reviewer understand what's going on -->

## Questions
None for now!
<!-- things you're uncertain about that you want the reviewer to focus on -->
