### PR TITLE
Fix AlerList no span attribute error

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1151,6 +1151,7 @@ class AlertList(object):
     onlyAlertsOnDashboard = attr.ib(default=True, validator=instance_of(bool))
     show = attr.ib(default=ALERTLIST_SHOW_CURRENT)
     sortOrder = attr.ib(default=SORT_ASC, validator=in_([1, 2, 3]))
+    span = attr.ib(default=None)
     stateFilter = attr.ib(default=attr.Factory(list))
     title = attr.ib(default="")
     transparent = attr.ib(default=False, validator=instance_of(bool))
@@ -1164,6 +1165,7 @@ class AlertList(object):
             'onlyAlertsOnDashboard': self.onlyAlertsOnDashboard,
             'show': self.show,
             'sortOrder': self.sortOrder,
+            'span': self.span,
             'stateFilter': self.stateFilter,
             'title': self.title,
             'transparent': self.transparent,

--- a/grafanalib/validators.py
+++ b/grafanalib/validators.py
@@ -33,10 +33,10 @@ def is_interval(instance, attribute, value):
     A validator that raises a :exc:`ValueError` if the attribute value is not
     matching regular expression.
     """
-    if not re.match("^[+-]?\d*[smhdMY]$", value):
+    if not re.match(r'^[+-]?\d*[smhdMY]$', value):
         raise ValueError(
             "valid interval should be a string "
-            "matching an expression: ^[+-]?\d*[smhdMY]$. "
+            r"matching an expression: ^[+-]?\d*[smhdMY]$. "
             "Examples: 24h 7d 1M +24h -24h")
 
 


### PR DESCRIPTION
## What does this do?
1. Add span attribute in AlertList
1. Fix W605 lint error for validators.py
## Why is it a good idea?
1. _balance_panels will throw following error without `span`
```
  File "/home/vagrant/python2/local/lib/python2.7/site-packages/grafanalib/core.py", line 438, in _balance_panels
    allotted_spans = sum(panel.span if panel.span else 0 for panel in panels)
  File "/home/vagrant/python2/local/lib/python2.7/site-packages/grafanalib/core.py", line 438, in <genexpr>
    allotted_spans = sum(panel.span if panel.span else 0 for panel in panels)
```
2. https://github.com/LintlyCI/Flake8Rules/blob/2929f6baefefabb08d62837a555e0752c95b2e55/_rules/W605.md
```
/home/ubuntu/virtualenvs/venv-system/bin/flake8 gfdatasource/gfdatasource grafanalib
grafanalib/validators.py:36:12: W605 invalid escape sequence '\d'
grafanalib/validators.py:38:27: W605 invalid escape sequence '\d'
make: *** [lint] Error 1

cd $SRCDIR; make all returned exit code 2
```

## Context
No
## Questions
No