### PR TITLE
Save test results on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ jobs:
     - run:
         name: make all
         command: |
-          mkdir -p test-results/tests
-          make JUNIT_XML=test-results/tests/junit.xml all
+          make all
     - store_test_results:
         path: test-results
     - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 dist/
 .uptodate
 /.env
-/junit-*.xml
+test-results/junit-*.xml
 /.cache
 .ensure-*
 /.tox

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27, py34, py35, py36
 
 [testenv]
-commands = pytest --junitxml=junit-{envname}.xml
+commands = pytest --junitxml=test-results/junit-{envname}.xml
 deps =
     pytest
 


### PR DESCRIPTION
The JUNIT_XML setting was erroneously brought over from another repo; here we can just tell `tox` to put the results in a subdir and save that.

Hoping nobody is relying on the exact location of test results right now.
