### PR TITLE
Update versions of Python tested

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: weaveworks/build-golang:1.11.1-stretch
+      - image: weaveworks/build-golang:1.13.3-stretch
     working_directory: /go/src/github.com/weaveworks/grafanalib
     environment:
       GOPATH: /go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,11 @@ jobs:
     - run:
         name: Dependencies
         command: |
-          pip install tox flake8
+          git clone --depth 1 -b v1.2.15 https://github.com/pyenv/pyenv.git $HOME/.pyenv
+          $HOME/.pyenv/bin/pyenv install 2.7.16
+          $HOME/.pyenv/bin/pyenv install 3.5.8
+          $HOME/.pyenv/bin/pyenv install 3.7.5
+          pip3 install tox flake8
           make deps
     - run:
         name: make all

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ IMAGE_NAMES=$(foreach dir,$(DOCKER_IMAGE_DIRS),$(patsubst %,$(IMAGE_PREFIX)/%,$(
 
 # Python-specific stuff
 TOX := $(shell command -v tox 2> /dev/null)
-PIP := $(shell command -v pip 2> /dev/null)
+PIP := $(shell command -v pip3 2> /dev/null)
 FLAKE8 := $(shell command -v flake8 2> /dev/null)
 
 .ensure-tox: .ensure-pip

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py35, py37
 
 [testenv]
 commands = pytest --junitxml=test-results/junit-{envname}.xml


### PR DESCRIPTION
Currently CI is only running Python 2.7; it seems like a good idea to run it against the newest version in common with the CircleCI 1.0 config and also the newest version as of today.

I used `pyenv` to run the installs, since this is what the CircleCI 1.0 config did.

EDIT: the upstream build image is now installing Python 3, which requires a couple more changes.