### PR TITLE
Add "for" param for alerts, Grafana 6.X

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.5.3 (2019-05-05)
+==================
+
+Changes
+-------
+
+* Add ``for`` parameter for alerts on Grafana 6.X
+
 0.5.2 (2018-07-19)
 ==================
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -835,6 +835,7 @@ class Alert(object):
     handler = attr.ib(default=1)
     noDataState = attr.ib(default=STATE_NO_DATA)
     notifications = attr.ib(default=attr.Factory(list))
+    gracePeriod = attr.ib(default='5m')
 
     def to_json_data(self):
         return {
@@ -846,6 +847,7 @@ class Alert(object):
             "name": self.name,
             "noDataState": self.noDataState,
             "notifications": self.notifications,
+            "for": self.gracePeriod,
         }
 
 


### PR DESCRIPTION
This parametr sets a grace period during which no notifications
are set.

## What does this do?
In Grafana 6.X (probably 5.X too), ``for`` parameter for alert sets grace period during which Grafana does not send notifications about firing alert.

