### PR TITLE
Set default sort order of "Weave" stacked-chart tooltips to DESC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/weaveworks/build-golang:1.11.1-stretch
+      - image: weaveworks/build-golang:1.11.1-stretch
     working_directory: /go/src/github.com/weaveworks/grafanalib
     environment:
       GOPATH: /go

--- a/grafanalib/weave.py
+++ b/grafanalib/weave.py
@@ -63,6 +63,7 @@ def stacked(graph):
         stack=True,
         fill=10,
         tooltip=G.Tooltip(
+            sort=G.SORT_DESC,
             valueType=G.INDIVIDUAL,
         ),
     )


### PR DESCRIPTION
- Easier to pick out the large outlier values if you have many series