### PR TITLE
Add 'diff', 'percent_diff' and 'count_non_null' as RTYPE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,13 @@ Changelog
 =========
 
 Next release
-==================
+=======
 
 Changes
 -------
 
 * Add ``for`` parameter for alerts on Grafana 6.X
+* Add 'diff', 'percent_diff' and 'count_non_null' as RTYPE
 
 0.5.3 (2018-07-19)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -120,7 +120,7 @@ EVAL_WITHIN_RANGE = "within_range"
 EVAL_OUTSIDE_RANGE = "outside_range"
 EVAL_NO_VALUE = "no_value"
 
-# Reducer Type avg/min/max/sum/count/last/median
+# Reducer Type avg/min/max/sum/count/last/median/diff/percent_diff/count_non_null
 RTYPE_AVG = "avg"
 RTYPE_MIN = "min"
 RTYPE_MAX = "max"
@@ -128,6 +128,9 @@ RTYPE_SUM = "sum"
 RTYPE_COUNT = "count"
 RTYPE_LAST = "last"
 RTYPE_MEDIAN = "median"
+RTYPE_DIFF = "diff"
+RTYPE_PERCENT_DIFF = "percent_diff"
+RTYPE_COUNT_NON_NULL = "count_non_null"
 
 # Condition Type
 CTYPE_QUERY = "query"

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -120,7 +120,7 @@ EVAL_WITHIN_RANGE = "within_range"
 EVAL_OUTSIDE_RANGE = "outside_range"
 EVAL_NO_VALUE = "no_value"
 
-# Reducer Type 
+# Reducer Type
 # avg/min/max/sum/count/last/median/diff/percent_diff/count_non_null
 RTYPE_AVG = "avg"
 RTYPE_MIN = "min"

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -120,7 +120,8 @@ EVAL_WITHIN_RANGE = "within_range"
 EVAL_OUTSIDE_RANGE = "outside_range"
 EVAL_NO_VALUE = "no_value"
 
-# Reducer Type avg/min/max/sum/count/last/median/diff/percent_diff/count_non_null
+# Reducer Type 
+# avg/min/max/sum/count/last/median/diff/percent_diff/count_non_null
 RTYPE_AVG = "avg"
 RTYPE_MIN = "min"
 RTYPE_MAX = "max"


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
Added 'diff', 'percent_diff' and 'count_non_null' as RTYPE for AlertConditions

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
It allows grafanalib to use those reducers in AlertConditions

## Context
<!-- any background that might help the reviewer understand what's going on -->
These three RTYPEs were missing in core.py

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
