### PR TITLE
Remove trailing spaces from separators

### DIFF
--- a/grafanalib/_gen.py
+++ b/grafanalib/_gen.py
@@ -43,7 +43,7 @@ class DashboardEncoder(json.JSONEncoder):
 def write_dashboard(dashboard, stream):
     json.dump(
         dashboard.to_json_data(), stream, sort_keys=True, indent=2,
-        cls=DashboardEncoder)
+        separators=(',', ':'), cls=DashboardEncoder)
     stream.write('\n')
 
 


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
This removes trailing spaces from separators (`:` and `,`) in the generated JSON.

## Why is it a good idea?
A trailing space, specially after the item separator (`,`), causes Go's YAML marshaling to escape any JSON data embedded inside YAML, instead of preserving line breaks and other escape sequences (using `|`).


This doesn't affect Python 3.4 and above where the default behaviour is changed to not include a whitespace after `,`:
>Changed in version 3.4: Use (',', ': ') as default if indent is not None