### PR TITLE
pin to attrs 19.2 and fix deprecated arguments

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -464,7 +464,7 @@ def _balance_panels(panels):
 class Row(object):
     # TODO: jml would like to separate the balancing behaviour from this
     # layer.
-    panels = attr.ib(default=attr.Factory(list), convert=_balance_panels)
+    panels = attr.ib(default=attr.Factory(list), converter=_balance_panels)
     collapse = attr.ib(
         default=False, validator=instance_of(bool),
     )
@@ -1008,7 +1008,7 @@ class Graph(object):
     # XXX: This isn't a *good* default, rather it's the default Grafana uses.
     yAxes = attr.ib(
         default=attr.Factory(YAxes),
-        convert=to_y_axes,
+        converter=to_y_axes,
         validator=instance_of(YAxes),
     )
     alert = attr.ib(default=None)

--- a/grafanalib/zabbix.py
+++ b/grafanalib/zabbix.py
@@ -821,7 +821,7 @@ class ZabbixTriggersPanel(object):
     transparent = attr.ib(default=False, validator=instance_of(bool))
     triggerSeverity = attr.ib(
         default=ZABBIX_SEVERITY_COLORS,
-        convert=convertZabbixSeverityColors,
+        converter=convertZabbixSeverityColors,
     )
     triggers = attr.ib(
         default=attr.Factory(ZabbixTrigger),

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Topic :: System :: Monitoring',
     ],
     install_requires=[
-        'attrs',
+        'attrs==19.2',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
## What does this do?
fixes method arguments that were deprecated in attrs, and removed intoday's attrs 19.2 release

## Why is it a good idea?
builds are broken at master right now