### PR TITLE
Use `converter` on attr.ib()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ Next release
 Changes
 -------
 
-TBA
+* use ``converter`` instead of ``convert`` on ``attr.ib()``
+    * https://github.com/python-attrs/attrs/issues/307
 
 0.5.4 (2019-08-30)
 =======

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -464,7 +464,7 @@ def _balance_panels(panels):
 class Row(object):
     # TODO: jml would like to separate the balancing behaviour from this
     # layer.
-    panels = attr.ib(default=attr.Factory(list), convert=_balance_panels)
+    panels = attr.ib(default=attr.Factory(list), converter=_balance_panels)
     collapse = attr.ib(
         default=False, validator=instance_of(bool),
     )
@@ -1008,7 +1008,7 @@ class Graph(object):
     # XXX: This isn't a *good* default, rather it's the default Grafana uses.
     yAxes = attr.ib(
         default=attr.Factory(YAxes),
-        convert=to_y_axes,
+        converter=to_y_axes,
         validator=instance_of(YAxes),
     )
     alert = attr.ib(default=None)

--- a/grafanalib/zabbix.py
+++ b/grafanalib/zabbix.py
@@ -821,7 +821,7 @@ class ZabbixTriggersPanel(object):
     transparent = attr.ib(default=False, validator=instance_of(bool))
     triggerSeverity = attr.ib(
         default=ZABBIX_SEVERITY_COLORS,
-        convert=convertZabbixSeverityColors,
+        converter=convertZabbixSeverityColors,
     )
     triggers = attr.ib(
         default=attr.Factory(ZabbixTrigger),


### PR DESCRIPTION
`convert` was deprecated in #307 of attrs
https://github.com/python-attrs/attrs/issues/307

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
Fixes broken attr.ib() calls referencing a deprecated kwarg

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
Installations of grafanalib do not work with newest attrs lib