### PR TITLE
Fix up load_source() call which doesn't exist in Python 3.5

### DIFF
--- a/grafanalib/_gen.py
+++ b/grafanalib/_gen.py
@@ -1,7 +1,6 @@
 """Generate JSON Grafana dashboards."""
 
 import argparse
-import importlib
 import json
 import os
 import sys
@@ -21,7 +20,14 @@ def load_dashboard(path):
         ``dashboard``.
     :return: A ``Dashboard``
     """
-    module = importlib.load_source("dashboard", path)
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 5:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("dashboard", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    else:
+        import importlib
+        module = importlib.load_source("dashboard", path)
     marker = object()
     dashboard = getattr(module, 'dashboard', marker)
     if dashboard is marker:


### PR DESCRIPTION
Add two different versions depending on the Python version

Fixes #191 