### PR TITLE
Create release workflow definition

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        pip install wheel;
+        rm -rf dist;
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}
+
+## Test work-flow - might be useful until we confirmed this working?
+#    - name: Publish distribution 📦 to Test PyPI
+#      uses: pypa/gh-action-pypi-publish@master
+#      with:
+#        password: ${{ secrets.test_pypi_password }}
+#        repository_url: https://test.pypi.org/legacy/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next release
 Changes
 -------
 
+* Automate publishing to PiPy with GitHub Actions
 * Update README.rst to make the example work
 
 0.5.4 (2019-08-30)


### PR DESCRIPTION
Following https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ in order to make releases happen automatically (#56)

The first test ran against test.pypi.org: https://github.com/dholbach/grafanalib/runs/446202668

Please review and let me know if this generally makes sense.