### PR TITLE
Update release instructions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,10 +1,10 @@
-name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distributions 📦 to PyPI
 
 on: push
 
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
@@ -22,10 +22,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_password }}
-
-## Test work-flow - might be useful until we confirmed this working?
-#    - name: Publish distribution 📦 to Test PyPI
-#      uses: pypa/gh-action-pypi-publish@master
-#      with:
-#        password: ${{ secrets.test_pypi_password }}
-#        repository_url: https://test.pypi.org/legacy/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,18 +2,27 @@
 Changelog
 =========
 
+Next release
+=======
+
+Changes
+-------
+
+* TBA
+
+
 0.5.5 (2020-02-17)
 =======
 
 It's been a while since the last release and we are happy to get this one into your hands.
-0.5.5 is a maintenance release, most importantly it adds support for Python > 3.5.
+0.5.5 is a maintenance release, most importantly it adds support for Python >= 3.5.
 
 We are very delighted to welcome Matt Richter on board as maintainer.
 
 Changes
 -------
 
-* Automate publishing to PiPy with GitHub Actions
+* Automate publishing to PyPI with GitHub Actions
 * Update README.rst to make the example work
 * Bump Dockerfile to use Alpine 3.10 as base
 * Fix up ``load_source()`` call which doesn't exist in Python 3.5

--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Support
 This library is in its very early stages. We'll probably make changes that
 break backwards compatibility, although we'll try hard not to.
 
-grafanalib works with Python 2.7, 3.4, 3.5, and 3.6.
+grafanalib works with Python 2.7, 3.4, 3.5, 3.6 and 3.7.
 
 Developing
 ==========
@@ -161,7 +161,7 @@ Getting Help
 If you have any questions about, feedback for or problems with ``grafanalib``:
 
 - Invite yourself to the `Weave Users Slack <https://slack.weave.works/>`_.
-- Ask a question on the `#general <https://weave-community.slack.com/messages/general/>`_ slack channel.
+- Ask a question on the `#grafanalib <https://weave-community.slack.com/messages/grafanalib/>`_ slack channel.
 - `File an issue <https://github.com/weaveworks/grafanalib/issues/new>`_.
 
 Your feedback is always welcome!

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -2,14 +2,39 @@
 Release process
 ===============
 
+Pre-release
+-----------
+
 * Pick a new version number (e.g. ``X.Y.Z``)
 * Update `CHANGELOG <../CHANGELOG.rst>`_ with that number
 * Update `setup.py <../setup.py>`_ with that number
-* Tag the repo with ``vX.Y.Z``
-* Upload to PyPI:
+
+Smoke-testing
+-------------
+
+* Run
 
       .. code-block:: console
 
-         $ rm -rf dist
-         $ python setup.py sdist bdist_wheel
-         $ twine upload dist/*
+         $ python setup.py install
+
+* Check ``~/.local/bin/generate-dashboard`` for the update version.
+* Try the example on `README <../README.rst>`_.
+
+Releasing
+---------
+
+* Head to `<https://github.com/weaveworks/grafanalib/releases/new>`_ and create the release there.
+* Wait for GitHub Actions to complete the build and release.
+* Confirm on `<https://pypi.org/project/grafanalib/>`_ that the release made it there.
+
+Follow-up
+---------
+
+* Run
+
+      .. code-block:: console
+
+         $ pip intall grafanalib -U
+
+* Check if the upgrade worked and the test above still passes.


### PR DESCRIPTION
- update release instructions with steps I used for 0.5.5
- fix typos in changelog
- add changelog entry for new release
- link to reopened grafanalib Slack channel
- mention 3.7 support on landing page