### PR TITLE
A lower-case `t` was preventing Table time column from formatting properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changes
 * Removed gfdatasource - feature is built in to Grafana since v5.
 * Generate API docs for readthedocs.org
 * Fix AlertList panel generation
+* Fix lowercase `"time"` pattern for default time_series column format in Table class
 
 0.5.5 (2020-02-17)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1556,7 +1556,7 @@ class Table(object):
                 type=DateColumnStyleType(),
             ),
             ColumnStyle(
-                alias="Time",
+                alias="time",
                 pattern="time",
                 type=DateColumnStyleType(),
             ),

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1552,7 +1552,7 @@ class Table(object):
         return [
             ColumnStyle(
                 alias="Time",
-                pattern="time",
+                pattern="Time",
                 type=DateColumnStyleType(),
             ),
             ColumnStyle(

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1556,6 +1556,11 @@ class Table(object):
                 type=DateColumnStyleType(),
             ),
             ColumnStyle(
+                alias="Time",
+                pattern="time",
+                type=DateColumnStyleType(),
+            ),
+            ColumnStyle(
                 pattern="/.*/",
             ),
         ]


### PR DESCRIPTION
## What does this do?
This changes the Table class's default ColumnStyle for "Time" to use upper case `T` instead of lower case `t` in its matching pattern. 

## Why is it a good idea?
In my scenario at least, the Timeseries data I got back had its time column labeled as `time` not `Time` so the time formatting was not being applied. 

## Questions
Is it universal that the data source will say capital T `Time` or does that vary? Should we cover both scenarios?