### PR TITLE
Drop test support for python 2.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
         name: Dependencies
         command: |
           git clone --depth 1 -b v1.2.15 https://github.com/pyenv/pyenv.git $HOME/.pyenv
-          $HOME/.pyenv/bin/pyenv install 2.7.16
           $HOME/.pyenv/bin/pyenv install 3.5.8
           $HOME/.pyenv/bin/pyenv install 3.7.5
           pip3 install --user tox flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Changes
 * Removed gfdatasource - feature is built in to Grafana since v5.
 * Generate API docs for readthedocs.org
 * Fix AlertList panel generation
+* Drop testing of Python 2.7, it has been EOL'ed and CI was broken
+  due to this.
 
 0.5.5 (2020-02-17)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ Support
 This library is in its very early stages. We'll probably make changes that
 break backwards compatibility, although we'll try hard not to.
 
-grafanalib works with Python 2.7, 3.4, 3.5, 3.6 and 3.7.
+grafanalib works with Python 3.4, 3.5, 3.6 and 3.7.
 
 Developing
 ==========

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py37
+envlist = py35, py37
 
 [testenv]
 commands = pytest --junitxml=test-results/junit-{envname}.xml


### PR DESCRIPTION
Tests seem to be failing for python 2.7 - as [it has been EOL'ed](https://pythonclock.org/), drop the testing of it.