### PR TITLE
Fix example showing up

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -7,7 +7,7 @@ COPY . .
 RUN pip3 install -r docs/requirements.txt && \
     apt update && apt install -y linkchecker && \
     python3 setup.py install && \
-    cd docs && make html && \
+    cd docs && mkdir _static && make html && \
     cd build/html/_static/fonts/RobotoSlab && \
     ln -s roboto-slab-v7-regular.eot roboto-slab.eot
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = build

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -18,7 +18,7 @@ The following will configure a dashboard with a single row, with one QPS graph
 broken down by status code and another latency graph showing median and 99th
 percentile latency:
 
-.. literalinclude:: example.dashboard.py
+.. literalinclude:: ../grafanalib/tests/examples/example.dashboard.py
    :language: python
 
 There is a fair bit of repetition here, but once you figure out what works for

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1590,7 +1590,7 @@ class Table(object):
         """Construct a table where each column has an associated style.
 
         :param columns: A list of (Column, ColumnStyle) pairs, where the
-            ColumnStyle is the style for the column and does **not** have a
+            ColumnStyle is the style for the column and does not have a
             pattern set (or the pattern is set to exactly the column name).
             The ColumnStyle may also be None.
         :param styles: An optional list of extra column styles that will be
@@ -1654,6 +1654,7 @@ class Threshold(object):
 @attr.s
 class BarGauge(object):
     """Generates Bar Gauge panel json structure
+
     :param allValue: If All values should be shown or a Calculation
     :param cacheTimeout: metric query result cache ttl
     :param calc: Calculation to perform on metrics
@@ -1791,6 +1792,7 @@ class BarGauge(object):
 @attr.s
 class GaugePanel(object):
     """Generates Gauge panel json structure
+
     :param allValue: If All values should be shown or a Calculation
     :param cacheTimeout: metric query result cache ttl
     :param calc: Calculation to perform on metrics
@@ -1808,7 +1810,7 @@ class GaugePanel(object):
     :param links: additional web links
     :param max: maximum value of the gauge
     :param maxDataPoints: maximum metric query results,
-        that will be used for rendering
+           that will be used for rendering
     :param min: minimum value of the gauge
     :param minSpan: minimum span number
     :param rangeMaps: the list of value to text mappings


### PR DESCRIPTION
The log file said:

```
/home/docs/checkouts/readthedocs.org/user_builds/grafanalib/checkouts/latest/docs/getting-started.rst:21: WARNING: Include file '/home/docs/checkouts/readthedocs.org/user_builds/grafanalib/checkouts/latest/docs/example.dashboard.py' not found or reading it failed
```

so I

- added '-W' to docs build to make sure we get references right
- fixed the example reference and
- fixed some docstrings
