### PR TITLE
Matthewmrichter/heatmaps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next release
 Changes
 -------
 
+* Add ``Heatmap`` class (and ``HeatmapColor``) to support the Heatmap panel (#170)
 * Add ``BarGuage`` for creating bar guages panels in grafana 6
 * Add ``GuagePanel`` for creating guages in grafana 6
 * Removed gfdatasource - feature is built in to Grafana since v5.

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1951,8 +1951,7 @@ class HeatmapColor(object):
 
 @attr.s
 class Heatmap(object):
-    """Generates Heatmap panel json structure
-    (https://grafana.com/docs/grafana/latest/features/panels/heatmap/)
+    """Generates Heatmap panel json structure (https://grafana.com/docs/grafana/latest/features/panels/heatmap/)
 
     :param heatmap
     :param cards: A heatmap card object: containing:

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -77,6 +77,7 @@ TEXT_TYPE = 'text'
 ALERTLIST_TYPE = "alertlist"
 BARGAUGE_TYPE = "bargauge"
 GAUGE_TYPE = "gauge"
+HEATMAP_TYPE = "heatmap"
 
 DEFAULT_FILL = 1
 DEFAULT_REFRESH = '10s'
@@ -1911,4 +1912,134 @@ class GaugePanel(object):
             "title": self.title,
             "transparent": self.transparent,
             "type": GAUGE_TYPE,
+        }
+
+@attr.s
+class HeatmapColor(object):
+    """A Color object for heatmaps
+
+    :param cardColor
+    :param colorScale
+    :param colorScheme
+    :param exponent
+    :param max
+    :param min
+    :param mode
+    """
+
+    # Maybe cardColor should validate to RGBA object, not sure
+    cardColor = attr.ib(default='#b4ff00', validator=instance_of(str))
+    colorScale = attr.ib(default='sqrt', validator=instance_of(str))
+    colorScheme = attr.ib(default='interpolateOranges')
+    exponent = attr.ib(default=0.5, validator=instance_of(float))
+    mode = attr.ib(default="spectrum", validator=instance_of(str))
+    max = attr.ib(default=None)
+    min = attr.ib(default=None)
+
+
+    def to_json_data(self):
+        return {
+            "mode": self.mode,
+            "cardColor": self.cardColor,
+            "colorScale": self.colorScale,
+            "exponent": self.exponent,
+            "colorScheme": self.colorScheme,
+            "max": self.max,
+            "min": self.min,
+        }
+
+@attr.s
+class Heatmap(object):
+    """Generates Heatmap panel json structure
+    (https://grafana.com/docs/grafana/latest/features/panels/heatmap/)
+
+    :param heatmap
+    :param cards: A heatmap card object: containing:
+        "cardPadding"
+        "cardRound"
+    :param color: Heatmap color object
+    :param dataFormat: 'timeseries' or 'tsbuckets'
+    :param yBucketBound: 'auto', 'upper', 'middle', 'lower'
+    :param reverseYBuckets: boolean
+    :param xBucketSize
+    :param xBucketNumber
+    :param yBucketSize
+    :param yBucketNumber
+    :param highlightCards: boolean
+    :param hideZeroBuckets: boolean
+    """
+
+    title = attr.ib()
+    description = attr.ib(default=None)
+    id = attr.ib(default=None)
+    # The below does not really like the Legend class we have defined above
+    legend = attr.ib(default={"show": False})
+    links = attr.ib(default=None)
+    targets = attr.ib(default=None)
+    tooltip = attr.ib(
+        default=attr.Factory(Tooltip),
+        validator=instance_of(Tooltip),
+    )
+    span = attr.ib(default=None)
+
+    cards = attr.ib(default={
+        "cardPadding": None,
+        "cardRound": None
+      })
+
+    color = attr.ib(
+        default=attr.Factory(HeatmapColor),
+        validator=instance_of(HeatmapColor),
+    )
+
+    dataFormat = attr.ib(default='timeseries')
+    datasource = attr.ib(default=None)
+    heatmap = {}
+    hideZeroBuckets = attr.ib(default=False)
+    highlightCards = attr.ib(default=True)
+    options = attr.ib(default=None)
+
+    xAxis = attr.ib(
+        default=attr.Factory(XAxis),
+        validator=instance_of(XAxis)
+    )
+    xBucketNumber = attr.ib(default=None)
+    xBucketSize = attr.ib(default=None)
+
+    yAxis = attr.ib(
+        default=attr.Factory(YAxis),
+        validator=instance_of(YAxis)
+    )
+    yBucketBound = attr.ib(default=None)
+    yBucketNumber = attr.ib(default=None)
+    yBucketSize = attr.ib(default=None)
+    reverseYBuckets = attr.ib(default=False)
+
+    def to_json_data(self):
+        return {
+            'cards': self.cards,
+            'color': self.color,
+            'dataFormat': self.dataFormat,
+            'datasource': self.datasource,
+            'description': self.description,
+            'heatmap': self.heatmap,
+            'hideZeroBuckets': self.hideZeroBuckets,
+            'highlightCards': self.highlightCards,
+            'id': self.id,
+            'legend': self.legend,
+            'links': self.links,
+            'options': self.options,
+            'reverseYBuckets': self.reverseYBuckets,
+            'span': self.span,
+            'targets': self.targets,
+            'title': self.title,
+            'tooltip': self.tooltip,
+            'type': HEATMAP_TYPE,
+            'xAxis': self.xAxis,
+            'xBucketNumber': self.xBucketNumber,
+            'xBucketSize': self.xBucketSize,
+            'yAxis': self.yAxis,
+            'yBucketBound': self.yBucketBound,
+            'yBucketNumber': self.yBucketNumber,
+            'yBucketSize': self.yBucketSize
         }

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1937,7 +1937,6 @@ class HeatmapColor(object):
     max = attr.ib(default=None)
     min = attr.ib(default=None)
 
-
     def to_json_data(self):
         return {
             "mode": self.mode,
@@ -1984,9 +1983,10 @@ class Heatmap(object):
     )
     span = attr.ib(default=None)
 
-    cards = attr.ib(default={
-        "cardPadding": None,
-        "cardRound": None
+    cards = attr.ib(
+        default={
+            "cardPadding": None,
+            "cardRound": None
         }
     )
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1914,6 +1914,7 @@ class GaugePanel(object):
             "type": GAUGE_TYPE,
         }
 
+
 @attr.s
 class HeatmapColor(object):
     """A Color object for heatmaps
@@ -1947,6 +1948,7 @@ class HeatmapColor(object):
             "max": self.max,
             "min": self.min,
         }
+
 
 @attr.s
 class Heatmap(object):
@@ -1985,7 +1987,8 @@ class Heatmap(object):
     cards = attr.ib(default={
         "cardPadding": None,
         "cardRound": None
-      })
+        }
+    )
 
     color = attr.ib(
         default=attr.Factory(HeatmapColor),

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1954,9 +1954,7 @@ class Heatmap(object):
     """Generates Heatmap panel json structure (https://grafana.com/docs/grafana/latest/features/panels/heatmap/)
 
     :param heatmap
-    :param cards: A heatmap card object: containing:
-        "cardPadding"
-        "cardRound"
+    :param cards: A heatmap card object: keys "cardPadding", "cardRound"
     :param color: Heatmap color object
     :param dataFormat: 'timeseries' or 'tsbuckets'
     :param yBucketBound: 'auto', 'upper', 'middle', 'lower'


### PR DESCRIPTION
## What does this do?
This PR adds initial support for the [Heatmap panel](https://grafana.com/docs/grafana/latest/features/panels/heatmap/). 

## Why is it a good idea?
Grafanalib should support all, or as many of the built in panel types as possible.

## Context
Issue #170 

At [Validity](validity.com), we have a few dashboards using heatmaps. I stubbed out these changes and tested them in our grafanalib client, and I was able to successfully render our heatmaps using the output. Example panel object: 

```
def assumerole_timings():
    return Heatmap(
        title = "assumeRole timings",
        color = color_default(),
        dataFormat = "tsbuckets",
        datasource = "$datasource",
        targets = [
            Target(
                expr = "sum(rate(kiam_sts_assumerole_timing_seconds_bucket[$interval])) by (le)",
                format = "heatmap",
                legendFormat = "{{le}}",
                refId = "A"
                )
            ],
        yAxis = YAxis(format = "s"),
        yBucketBound = "upper"
    )
```