### PR TITLE
Bugfix for Elasticsearch TermsGroupBy ordering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changes
 * Add support for custom variables.
 * Point out documentation on readthedocs more clearly.
 * Add average metric aggregation for elastic search
+* Bugfix to query ordering in Elasticsearch TermsGroupBy
 
 0.5.5 (2020-02-17)
 ==================

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -178,7 +178,7 @@ class TermsGroupBy(object):
             'settings': {
                 'min_doc_count': self.minDocCount,
                 'order': self.order,
-                'order_by': self.orderBy,
+                'orderBy': self.orderBy,
                 'size': self.size,
             },
         }


### PR DESCRIPTION
## What does this do?
This provides a bugfix to the Elasticsearch TermsGroupBy multi-bucket aggregator. This aggregator currently outputs a JSON field named order_by, whereas grafana uses the field name orderBy. This  commit updates grafanalib to match the required grafana JSON format.

## Why is it a good idea?
This causes ordering in Elasticsearch term aggregation to function as intended.

## Context
This discrepancy can be seen by looking at the output JSON for the example Elasticsearch dashboard panels on the play.grafanalib.org site. There, the ordering output is placed under the orderBy field, rather than the order_by field. The effects of this become noticeable when using TermsGroupBy to plot Elasticsearch timeseries data, where the colouring/ouptut ordering will change every time a new Elasticsearch query is executed.
