### PR TITLE
Update to new junit_family

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py35, py37, py38
 
 [testenv]
-commands = pytest --junitxml=test-results/junit-{envname}.xml
+commands = pytest -o junit_family=xunit2 --junitxml=test-results/junit-{envname}.xml
 deps =
     pytest
 


### PR DESCRIPTION
Thanks Oriol Pauleria for the fix: https://github.com/weaveworks/grafanalib/pull/184/files#r349836896

closes: #223

After applying this and running `tox`, the error message in #223 does not appear any more.