### PR TITLE
Use attr.evolve instead of attr.assoc

### DIFF
--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -209,7 +209,7 @@ class ElasticsearchTarget(object):
     refId = attr.ib(default="", validator=instance_of(str))
 
     def _map_bucket_aggs(self, f):
-        return attr.assoc(self, bucketAggs=list(map(f, self.bucketAggs)))
+        return attr.evolve(self, bucketAggs=list(map(f, self.bucketAggs)))
 
     def auto_bucket_agg_ids(self):
         """Give unique IDs all bucketAggs without ID.


### PR DESCRIPTION
Apparently `attr.assoc` has been replaced by `attr.evolve` since a long time ago: https://www.attrs.org/en/stable/api.html#attr.assoc

closes: #224

Applying the PR and running `tox` won't show the warning mentioned in #224 
