### PR TITLE
Update BarGauge and GaugePanel default Threshold values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changes
 * Add average metric aggregation for elastic search
 * Bugfix to query ordering in Elasticsearch TermsGroupBy
 * Added all parameters for StringColumnStyle
+* Bugfix to update default ``Threshold`` values for ``GaugePanel`` and ``BarGauge``
 
 0.5.5 (2020-02-17)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1765,8 +1765,8 @@ class BarGauge(object):
     thresholds = attr.ib(
         default=attr.Factory(
             lambda: [
-                Threshold("green", 0, 0),
-                Threshold("red", 1, 80)
+                Threshold("green", 0, 0.0),
+                Threshold("red", 1, 80.0)
             ]
         ),
         validator=instance_of(list),
@@ -1887,8 +1887,8 @@ class GaugePanel(object):
     thresholds = attr.ib(
         default=attr.Factory(
             lambda: [
-                Threshold("green", 0, 0),
-                Threshold("red", 1, 80)
+                Threshold("green", 0, 0.0),
+                Threshold("red", 1, 80.0)
             ]
         ),
         validator=instance_of(list),


### PR DESCRIPTION

## What does this do?
[`Threshold` values should be of the type float.](https://github.com/weaveworks/grafanalib/blob/master/grafanalib/core.py#L1676) The default `Thresholds` for `BarGauge` and `GaugePanel` cause a `TypeError` to be thrown when a custom `Threshold` isn't set because an integer is passed as the third argument to `Threshold` when a float is required.

## Why is it a good idea?
I expected that `BarGauge` would render out-of-the-box if I provided the minimal required inputs as described by the docs: `title` and `targets`. Here is the setup that causes the `TypeError` mentioned above.

```python3
BarGauge(
    max=500,
    min=0,
    span=6,
    targets=[
        Target(
            target="highestAverage(aliasByNode(stats.timers.$page.api_calls.$device.$identity.$endpoints.median, 6), 10)"
        )
    ],
    title="This is some data"
),
```

## Context
Here is the error output from the code above. By updating these defaults, users will be able to use `BarGauge` and `GaugePanel` when providing only the required arguments.

```python3
grafana-dashboards-dev-builder | Traceback (most recent call last):
grafana-dashboards-dev-builder |   File "builder/main.py", line 86, in <module>
grafana-dashboards-dev-builder |     main()
grafana-dashboards-dev-builder |   File "builder/main.py", line 29, in main
grafana-dashboards-dev-builder |     compiled_dashboard_path_to_json_string_dicts = [
grafana-dashboards-dev-builder |   File "builder/main.py", line 30, in <listcomp>
grafana-dashboards-dev-builder |     Compiler(
grafana-dashboards-dev-builder |   File "/app/builder/compiler/compiler.py", line 21, in get_compiled_dashboard_path_to_json_string_dict
grafana-dashboards-dev-builder |     self.config.get_json_string_for_target_dashboard_path(
grafana-dashboards-dev-builder |   File "/app/builder/compiler/config/py_config.py", line 21, in get_json_string_for_target_dashboard_path
grafana-dashboards-dev-builder |     dashboard = load_dashboard(str(target_dashboard_path))
grafana-dashboards-dev-builder |   File "/usr/local/lib/python3.8/site-packages/grafanalib/_gen.py", line 27, in load_dashboard
grafana-dashboards-dev-builder |     spec.loader.exec_module(module)
grafana-dashboards-dev-builder |   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
grafana-dashboards-dev-builder |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
grafana-dashboards-dev-builder |   File "/app/py_dashboards/dashboards/recommendations/hp-performance.dashboard.py", line 296, in <module>
grafana-dashboards-dev-builder |     BarGauge(
grafana-dashboards-dev-builder |   File "<attrs generated init grafanalib.core.BarGauge>", line 39, in __init__
grafana-dashboards-dev-builder |   File "/usr/local/lib/python3.8/site-packages/grafanalib/core.py", line 1768, in <lambda>
grafana-dashboards-dev-builder |     Threshold("green", 0, 0),
grafana-dashboards-dev-builder |   File "<attrs generated init grafanalib.core.Threshold>", line 7, in __init__
grafana-dashboards-dev-builder |   File "/usr/local/lib/python3.8/site-packages/attr/validators.py", line 35, in __call__
grafana-dashboards-dev-builder |     raise TypeError(
grafana-dashboards-dev-builder | TypeError: ("'value' must be <class 'float'> (got 0 that is a <class 'int'>).", Attribute(name='value', default=NOTHING, validator=<instance_of validator for type <class 'float'>>, repr=True, eq=True, order=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None, kw_only=False), <class 'float'>, 0)
grafana-dashboards-dev-builder | make: *** [Makefile:7: build] Error 1
```

## Questions