### PR TITLE
Add Elasticsearch bucket script aggregator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
 Changes
 -------
 
+* Add Elasticsearch bucket script pipeline aggregator
 * ...
 
 

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -142,6 +142,42 @@ class DateHistogramGroupBy(object):
 
 
 @attr.s
+class BucketScriptAgg(object):
+    """An aggregator that applies a bucket script to the results of previous aggregations.
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
+
+    :param fields: dictionary of field names mapped to aggregation IDs to be used in the bucket script
+                   e.g. { "field1":1 }, which allows the output of aggregate ID 1 to be referenced as
+                        params.field1 in the bucket script
+    :param script: script to apply to the data using the variables specified in 'fields'
+    :param id: id of the aggregator
+    :param hide: show/hide the metric in the final panel display
+    """
+    fields = attr.ib(default={}, validator=instance_of(dict))
+    id = attr.ib(default=0, validator=instance_of(int))
+    hide = attr.ib(default=False, validator=instance_of(bool))
+    script = attr.ib(default="", validator=instance_of(str))
+
+    def to_json_data(self):
+        pipelineVars = []
+        for field in self.fields:
+            pipelineVars.append({
+                "name": str(field),
+                "pipelineAgg": str(self.fields[field])
+            })
+
+        return {
+            'type': 'bucket_script',
+            'id': str(self.id),
+            'hide': self.hide,
+            'pipelineVariables': pipelineVars,
+            'settings': {
+                'script': self.script
+            },
+        }
+
+
+@attr.s
 class Filter(object):
     """ A Filter for a FilterGroupBy aggregator.
 


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
This adds support for the Elasticsearch bucket script pipeline aggregator
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html 

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
This is one of the core elasticsearch pipeline aggregations, and is natively supported by Grafana. 
It allows the user to combine the output of previous metric aggregations, using 
Elasticsearch Painless inline scripting.

## Context
<!-- any background that might help the reviewer understand what's going on -->
Being able to apply scripts to the results of Elasticsearch metric aggregations can be very useful,
e.g. allowing one to plot the ratio of two sums over different document fields, as was my use case.

This includes id and hiding capabilities for the bucket script aggregator, as implemented elsewhere in #231

The Painless scripting docs are here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-painless.html

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->