### PR TITLE
Curl default behavior is to STDOUT content

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Generate the JSON dashboard like so:
 
 .. code-block:: console
 
-  $ curl https://raw.githubusercontent.com/weaveworks/grafanalib/master/grafanalib/tests/examples/example.dashboard.py
+  $ curl -o example.dashboard.py https://raw.githubusercontent.com/weaveworks/grafanalib/master/grafanalib/tests/examples/example.dashboard.py
   $ generate-dashboard -o frontend.json example.dashboard.py
 
 


### PR DESCRIPTION
## What does this do?
Simple fix of the README:

Curl on linux by default output the content of the downloaded file on the STDOUT (you are maybe using MacOSX and I don't know curl's default behavior on MacOSX?). Add the `-o` option and the name of the file to create. Using `wget` maybe more portable?

## Why is it a good idea?

Either there is an error in the README, or this would be more portable (between OSes).