### PR TITLE
Add support for the Stat panel, which replaces SingleStat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changes
 * Add Elasticsearch bucket script pipeline aggregator
 * Added ability to hide metrics for Elasticsearch MetricAggs
 * Add derivative metric aggregation for Elasticsearch
+* Add ``Stat`` class (and ``StatMapping``, ``StatValueMapping``, ``StatRangeMapping``) to support the Stat panel
 * ...
 
 


### PR DESCRIPTION
## What does this do?
The SingleStat panel was deprecated in Grafana 7.0, Stat is thethe replacement for this.
The Stat panel uses a new mappings format so the classes StatMapping, StatValueMapping and StatRangeMapping were also added to support this.

## Why is it a good idea?
Allows users to make use of the Stat panel in the latest version of Grafana

## Context
Closes #253 

## Questions
The new mappings format is valid for not just the Stat panel, but didn't want to complicate this with the existing `Mapping` and `ValueMap` and `RangeMap` classes. Let me know if you think there is a better way to maintain backwards compatibility. 
