### PR TITLE
Adding Alert Threshold flag to Graphs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 0.5.9 (TBD)
 ===========
 
+* Added Alert Threshold enabled/disabled to Graphs.
+
 Changes
 -------
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1061,6 +1061,7 @@ class Graph(object):
 
     title = attr.ib()
     targets = attr.ib()
+    alertThreshold = attr.ib(default=True, validator=instance_of(bool))
     aliasColors = attr.ib(default=attr.Factory(dict))
     bars = attr.ib(default=False, validator=instance_of(bool))
     dataLinks = attr.ib(default=attr.Factory(list))
@@ -1126,6 +1127,7 @@ class Graph(object):
             'nullPointMode': self.nullPointMode,
             'options': {
                 'dataLinks': self.dataLinks,
+                'alertThreshold': self.alertThreshold,
             },
             'percentage': self.percentage,
             'pointradius': self.pointRadius,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
We found out that on [Grafana 7.2.0-beta1](https://github.com/grafana/grafana/blob/master/CHANGELOG.md#720-beta1-2020-09-09) adds toggle to disable alert threshold visibility in graph panel was added. I would like `grafanalib` to support it.

![Selection_158](https://user-images.githubusercontent.com/121728/98307334-d22b3f00-1fc5-11eb-86b7-f684948ebd8a.png)

This PR adds an option on the Graph class to be able to toggle that setting (`alertThreshold`).

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
To support this new flag on `grafanalib`.

## Context
Please check first title (What does this do). After checking how the json looked like on an instance of a graph using Grafana 7.3.0, decided to add the parameter that this PR describes to support the new attribute.
Didn't test on a real case. Just added the parameter and the serialization of the attribute.
Tests are passing locally.

## Questions
No questions from my side.
