### PR TITLE
Add support for repetition to the Stat panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 
 * Added Alert Threshold enabled/disabled to Graphs.
 * Added constants for all Grafana value formats
+* Added support for repetitions to Stat Panels (https://grafana.com/docs/grafana/latest/variables/repeat-panels-or-rows/)
 
 Changes
 -------

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -354,17 +354,18 @@ def is_valid_max_per_row(instance, attribute, value):
 
 @attr.s
 class Repeat(object):
-   """
-   Panel repetition settings.
+    """
+    Panel repetition settings.
 
-   :param direction: The direction into which to repeat ('h' or 'v')
-   :param variable: The name of the variable over whose values to repeat
-   :param maxPerRow: The maximum number of panels per row in horizontal repetition
-   """
+    :param direction: The direction into which to repeat ('h' or 'v')
+    :param variable: The name of the variable over whose values to repeat
+    :param maxPerRow: The maximum number of panels per row in horizontal repetition
+    """
 
-   direction = attr.ib(default=None)
-   variable = attr.ib(default=None)
-   maxPerRow = attr.ib(default=None, validator=is_valid_max_per_row)
+    direction = attr.ib(default=None)
+    variable = attr.ib(default=None)
+    maxPerRow = attr.ib(default=None, validator=is_valid_max_per_row)
+
 
 @attr.s
 class Target(object):

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -347,7 +347,7 @@ class Legend(object):
 
 
 def is_valid_max_per_row(instance, attribute, value):
-    if ((value != None) and not isinstance(value, int)):
+    if ((value is not None) and not isinstance(value, int)):
         raise ValueError("{attr} should either be None or an integer".format(
             attr=attribute))
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -346,6 +346,26 @@ class Legend(object):
         }
 
 
+def is_valid_max_per_row(instance, attribute, value):
+    if ((value != None) and not isinstance(value, int)):
+        raise ValueError("{attr} should either be None or an integer".format(
+            attr=attribute))
+
+
+@attr.s
+class Repeat(object):
+   """
+   Panel repetition settings.
+
+   :param direction: The direction into which to repeat ('h' or 'v')
+   :param variable: The name of the variable over whose values to repeat
+   :param maxPerRow: The maximum number of panels per row in horizontal repetition
+   """
+
+   direction = attr.ib(default=None)
+   variable = attr.ib(default=None)
+   maxPerRow = attr.ib(default=None, validator=is_valid_max_per_row)
+
 @attr.s
 class Target(object):
     """
@@ -1346,6 +1366,7 @@ class Stat(object):
     :param span: defines the number of spans that will be used for panel
     :param thresholds: single stat thresholds
     :param transparent: defines if the panel should be transparent
+    :param repeat: defines how the panel should be repeated
     """
 
     dataSource = attr.ib()
@@ -1368,6 +1389,7 @@ class Stat(object):
     transparent = attr.ib(default=False, validator=instance_of(bool))
     reduceCalc = attr.ib(default='mean', type=str)
     decimals = attr.ib(default=None)
+    repeat = attr.ib(default=attr.Factory(Repeat), validator=instance_of(Repeat))
 
     def to_json_data(self):
         return {
@@ -1408,6 +1430,9 @@ class Stat(object):
             'transparent': self.transparent,
             'type': STAT_TYPE,
             'timeFrom': self.timeFrom,
+            'repeat': self.repeat.variable,
+            'repeatDirection': self.repeat.direction,
+            'maxPerRow': self.repeat.maxPerRow
         }
 
 

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -88,9 +88,9 @@ def test_stat_no_repeat():
         ]
     )
 
-    assert t.to_json_data()['repeat'] == None
-    assert t.to_json_data()['repeatDirection'] == None
-    assert t.to_json_data()['maxPerRow'] == None
+    assert t.to_json_data()['repeat'] is None
+    assert t.to_json_data()['repeatDirection'] is None
+    assert t.to_json_data()['maxPerRow'] is None
 
 
 def test_stat_with_repeat():

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -79,6 +79,39 @@ def test_table_styled_columns():
     ]
 
 
+def test_stat_no_repeat():
+    t = G.Stat(
+        title='dummy',
+        dataSource='data source',
+        targets=[
+            G.Target(expr='some expr')
+        ]
+    )
+
+    assert t.to_json_data()['repeat'] == None
+    assert t.to_json_data()['repeatDirection'] == None
+    assert t.to_json_data()['maxPerRow'] == None
+
+
+def test_stat_with_repeat():
+    t = G.Stat(
+        title='dummy',
+        dataSource='data source',
+        targets=[
+            G.Target(expr='some expr')
+        ],
+        repeat=G.Repeat(
+            variable="repetitionVariable",
+            direction='h',
+            maxPerRow=10
+        )
+    )
+
+    assert t.to_json_data()['repeat'] == 'repetitionVariable'
+    assert t.to_json_data()['repeatDirection'] == 'h'
+    assert t.to_json_data()['maxPerRow'] == 10
+
+
 def test_single_stat():
     data_source = 'dummy data source'
     targets = ['dummy_prom_query']


### PR DESCRIPTION
Extend the Stat panel with support for repetitions.

I am using Stat panels in overview dashboards. Stat panels should be repeated according to the content of a variable (in my case the variable contains all tags from a certain measurement).

Without this little change, I had to generate the dashboard and either amend the missing repetitions by jq or later add them manually in Grafana. My intention is to generate the entire Grafana content completely automated.