### PR TITLE
Add support for alias expressions in data targets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 * Added Alert Threshold enabled/disabled to Graphs.
 * Added constants for all Grafana value formats
 * Added support for repetitions to Stat Panels (https://grafana.com/docs/grafana/latest/variables/repeat-panels-or-rows/)
+* Added support for an alias expression in targets
 
 Changes
 -------

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -386,6 +386,7 @@ class Target(object):
     target = attr.ib(default="")
     instant = attr.ib(validator=instance_of(bool), default=False)
     datasource = attr.ib(default="")
+    alias = attr.ib(default=None)
 
     def to_json_data(self):
         return {
@@ -400,6 +401,7 @@ class Target(object):
             'step': self.step,
             'instant': self.instant,
             'datasource': self.datasource,
+            'alias': self.alias
         }
 
 


### PR DESCRIPTION
Grafana allows setting an alias expression in a data target so that it gets identified nicely in the resulting graph. `Target` did not yet allow setting such an alias.

Add a simple `alias` field to the `Target` class so that the selected data can be aliased with an arbitrary expression.