### PR TITLE
Use pytest --strict-marker over --strict

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     coverage
     pytest
 commands =
-    python -m coverage run --rcfile=.coveragerc -m pytest --strict --maxfail=1 --ff {posargs}
+    python -m coverage run --rcfile=.coveragerc -m pytest --strict-markers --maxfail=1 --ff {posargs}
     # Had 88% test coverage at time of introducing coverage ratchet.
     # This number must only go up.
     python -m coverage report --rcfile=.coveragerc --show-missing --fail-under=88


### PR DESCRIPTION
Removes deprecation warning from pytest
