### PR TITLE
Enable use with pre-17.4.0 versions of attr.

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -542,7 +542,10 @@ def _balance_panels(panels):
 class Row(object):
     # TODO: jml would like to separate the balancing behaviour from this
     # layer.
-    panels = attr.ib(default=attr.Factory(list), converter=_balance_panels)
+    try:
+        panels = attr.ib(default=attr.Factory(list), converter=_balance_panels)
+    except TypeError:
+        panels = attr.ib(default=attr.Factory(list), convert=_balance_panels)
     collapse = attr.ib(
         default=False, validator=instance_of(bool),
     )
@@ -1194,11 +1197,18 @@ class Graph(Panel):
     )
     xAxis = attr.ib(default=attr.Factory(XAxis), validator=instance_of(XAxis))
     # XXX: This isn't a *good* default, rather it's the default Grafana uses.
-    yAxes = attr.ib(
-        default=attr.Factory(YAxes),
-        converter=to_y_axes,
-        validator=instance_of(YAxes),
-    )
+    try:
+        yAxes = attr.ib(
+            default=attr.Factory(YAxes),
+            converter=to_y_axes,
+            validator=instance_of(YAxes),
+        )
+    except TypeError:
+        yAxes = attr.ib(
+            default=attr.Factory(YAxes),
+            convert=to_y_axes,
+            validator=instance_of(YAxes),
+        )
     alert = attr.ib(default=None)
 
     def to_json_data(self):

--- a/grafanalib/zabbix.py
+++ b/grafanalib/zabbix.py
@@ -819,10 +819,16 @@ class ZabbixTriggersPanel(object):
     span = attr.ib(default=None)
     statusField = attr.ib(default=False, validator=instance_of(bool))
     transparent = attr.ib(default=False, validator=instance_of(bool))
-    triggerSeverity = attr.ib(
-        default=ZABBIX_SEVERITY_COLORS,
-        converter=convertZabbixSeverityColors,
-    )
+    try:
+        triggerSeverity = attr.ib(
+            default=ZABBIX_SEVERITY_COLORS,
+            converter=convertZabbixSeverityColors,
+        )
+    except TypeError:
+        triggerSeverity = attr.ib(
+            default=ZABBIX_SEVERITY_COLORS,
+            convert=convertZabbixSeverityColors,
+        )
     triggers = attr.ib(
         default=attr.Factory(ZabbixTrigger),
         validator=instance_of(ZabbixTrigger),

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Topic :: System :: Monitoring',
     ],
     install_requires=[
-        'attrs==20.3.0',
+        'attrs',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
PR #180 updated Grafanalib to work with attr versions post 19.2.0, when
keyword argument convert to attr.ib() was removed. It had been
deprecated in 17.4.0, and renamed to converter.

This change revises the change to work with both varieties of attr.ib(),
and so removes version requirements for attr. Those working on
antediluvian systems can use whatever system packaged version of attr is
available, a convenience when packaging Grafanalib.


