### PR TITLE
Add elasticsearch alert condition override

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 * Added option to hide dashboard time picker
 * Added Notification for Alert
 * Added alertRuleTags field to the graph panel
+* Added support for Elasticsearch alert condition
 
 Changes
 -------

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -940,7 +940,7 @@ class AlertCondition(object):
     timeRange = attr.ib(validator=instance_of(TimeRange))
     operator = attr.ib()
     reducerType = attr.ib()
-    type = attr.ib(default=CTYPE_QUERY)
+    type = attr.ib(default=CTYPE_QUERY, kw_only=True)
 
     def to_json_data(self):
         queryParams = [

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -3,6 +3,7 @@
 import attr
 import itertools
 from attr.validators import instance_of
+from grafanalib.core import AlertCondition
 
 DATE_HISTOGRAM_DEFAULT_FIELD = 'time_iso8601'
 ORDER_ASC = 'asc'
@@ -362,3 +363,26 @@ class ElasticsearchTarget(object):
             'query': self.query,
             'refId': self.refId,
         }
+
+
+@attr.s
+class ElasticsearchAlertCondition(AlertCondition):
+    """
+    Override alert condition to support Elasticseach target.
+
+    See AlertCondition for more information.
+
+    :param Target target: Metric the alert condition is based on.
+    :param Evaluator evaluator: How we decide whether we should alert on the
+        metric. e.g. ``GreaterThan(5)`` means the metric must be greater than 5
+        to trigger the condition. See ``GreaterThan``, ``LowerThan``,
+        ``WithinRange``, ``OutsideRange``, ``NoValue``.
+    :param TimeRange timeRange: How long the condition must be true for before
+        we alert.
+    :param operator: One of ``OP_AND`` or ``OP_OR``. How this condition
+        combines with other conditions.
+    :param reducerType: RTYPE_*
+    :param type: CTYPE_*
+    """
+
+    target = attr.ib(validator=instance_of(ElasticsearchTarget))


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
AlertCondition should contain the ElasticsearchTarget but since ElasticsearchTarget doesn't inherit from Target you get a validator the error


Closes  #322

