### PR TITLE
Adding humio datasource. 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.5.10 (2021-03-12)
+==================
+
+Changes
+-------
+
+* Added support for Humio Data Source. (https://grafana.com/grafana/plugins/humio-datasource/)
+
+
 0.x.x (TBD)
 ===========
 

--- a/grafanalib/humio.py
+++ b/grafanalib/humio.py
@@ -1,6 +1,5 @@
-"""humioQuery: options.annotation.humioQuery,
-humioRepository: options.annotation.humioRepository,
-refId: options.annotation.refId"""
+"""Helpers to create Humio-specific Grafana queries."""
+
 import attr
 
 
@@ -14,7 +13,7 @@ class HumioTarget(object):
     Humio docs on query language https://docs.humio.com/reference/language-syntax/
 
     :param humioQuery: Query that will be executed on Humio
-    :param humioRepository: Repositry to execute query on.
+    :param humioRepository: Repository to execute query on.
     :param refId: target reference id
     """
 

--- a/grafanalib/humio.py
+++ b/grafanalib/humio.py
@@ -1,0 +1,31 @@
+"""humioQuery: options.annotation.humioQuery,
+humioRepository: options.annotation.humioRepository,
+refId: options.annotation.refId"""
+import attr
+
+
+@attr.s
+class HumioTarget(object):
+    """
+    Generates Humio target JSON structure.
+
+    Link to Humio Grafana plugin https://grafana.com/grafana/plugins/humio-datasource/
+
+    Humio docs on query language https://docs.humio.com/reference/language-syntax/
+
+    :param humioQuery: Query that will be executed on Humio
+    :param humioRepository: Repositry to execute query on.
+    :param refId: target reference id
+    """
+
+    humioQuery = attr.ib(default="")
+    humioRepository = attr.ib(default="")
+    refId = attr.ib(default="")
+
+    def to_json_data(self):
+
+        return {
+            "humioQuery": self.humioQuery,
+            "humioRepository": self.humioRepository,
+            "refId": self.refId
+        }

--- a/grafanalib/tests/test_humio.py
+++ b/grafanalib/tests/test_humio.py
@@ -6,7 +6,7 @@ from grafanalib import _gen
 from io import StringIO
 
 
-def test_serialization_cloudwatch_metrics_target():
+def test_serialization_humio_metrics_target():
     """Serializing a graph doesn't explode."""
     graph = G.Graph(
         title="Humio Logs",

--- a/grafanalib/tests/test_humio.py
+++ b/grafanalib/tests/test_humio.py
@@ -1,0 +1,25 @@
+"""Tests for Humio Datasource"""
+
+import grafanalib.core as G
+import grafanalib.humio as H
+from grafanalib import _gen
+from io import StringIO
+
+
+def test_serialization_cloudwatch_metrics_target():
+    """Serializing a graph doesn't explode."""
+    graph = G.Graph(
+        title="Humio Logs",
+        dataSource="Humio data source",
+        targets=[
+            H.HumioTarget(),
+        ],
+        id=1,
+        yAxes=G.YAxes(
+            G.YAxis(format=G.SHORT_FORMAT, label="ms"),
+            G.YAxis(format=G.SHORT_FORMAT),
+        ),
+    )
+    stream = StringIO()
+    _gen.write_dashboard(graph, stream)
+    assert stream.getvalue() != ''


### PR DESCRIPTION
Humio is available as a plugin datasource, documented [here](https://grafana.com/grafana/plugins/humio-datasource/).
The Humio query language is documented [here](https://docs.humio.com/reference/language-syntax/). 

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Adding support for Humio queries in grafanalib.

## Why is it a good idea?
Humio is offered as a plugin datasource in Grafana, and adding this will allow people to create graphs with Humio data. 

## Context
Humio is a log aggregation, storage, and analysis tool similar to Elasticsearch. It is available as both as self-hosted or as a SaaS product.  

## Questions

