### PR TITLE
Fix Repeat for Panel

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1263,7 +1263,6 @@ class Graph(Panel):
     :param dataLinks: List of data links hooked to datapoints on the graph
     :param dataSource: DataSource's name
     :param minSpan: Minimum width for each panel
-    :param repeat: Template's name to repeat Graph on
     :param thresholds: List of GraphThresholds - Only valid when alert not defined
     """
 
@@ -1531,7 +1530,6 @@ class Stat(Panel):
     :param span: defines the number of spans that will be used for panel
     :param thresholds: single stat thresholds
     :param transparent: defines if the panel should be transparent
-    :param repeat: defines how the panel should be repeated
     """
 
     textMode = attr.ib(default='auto')
@@ -1545,7 +1543,6 @@ class Stat(Panel):
     thresholds = attr.ib(default="")
     reduceCalc = attr.ib(default='mean', type=str)
     decimals = attr.ib(default=None)
-    repeat = attr.ib(default=attr.Factory(Repeat), validator=instance_of(Repeat))
 
     def to_json_data(self):
         return self.panel_json(

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1137,7 +1137,7 @@ class Panel(object):
     links = attr.ib(default=attr.Factory(list))
     maxDataPoints = attr.ib(default=100)
     minSpan = attr.ib(default=None)
-    repeat = attr.ib(default=None)
+    repeat = attr.ib(default=attr.Factory(Repeat), validator=instance_of(Repeat))
     span = attr.ib(default=None)
     timeFrom = attr.ib(default=None)
     timeShift = attr.ib(default=None)
@@ -1161,7 +1161,9 @@ class Panel(object):
             'links': self.links,
             'maxDataPoints': self.maxDataPoints,
             'minSpan': self.minSpan,
-            'repeat': self.repeat,
+            'repeat': self.repeat.variable,
+            'repeatDirection': self.repeat.direction,
+            'maxPerRow': self.repeat.maxPerRow,
             'span': self.span,
             'targets': self.targets,
             'timeFrom': self.timeFrom,
@@ -1575,9 +1577,6 @@ class Stat(Panel):
                     }
                 },
                 'type': STAT_TYPE,
-                'repeat': self.repeat.variable,
-                'repeatDirection': self.repeat.direction,
-                'maxPerRow': self.repeat.maxPerRow
             }
         )
 


### PR DESCRIPTION

## What does this do?

Repeat is an object so isn't json serializable this change will add the necessary fields to the pannel object so that we can create repeat panels. 

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

This is a bug fix. 

## Context
<!-- any background that might help the reviewer understand what's going on -->

Tested locally and was able to create repeated panels. 
## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
