### PR TITLE
Set target datasource as None instead of empty string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ x.x.x (TBD)
 ==================
 
 * Added ...
+* Fix default target datasource to work with newer versions of Grafana
 
 
 Changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,16 +6,16 @@ x.x.x (TBD)
 ==================
 
 * Added ...
-* Fix default target datasource to work with newer versions of Grafana
+
 
 
 Changes
 -------
 
-* Changed ...
+* Fix default target datasource to work with newer versions of Grafana
 
 
-0.5.1 (2021-04-06)
+0.5.10 (2021-04-06)
 ===========
 
 * Added timeField field for the Elasticsearch target to allow the alert to change its state

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -390,7 +390,7 @@ class Target(object):
     step = attr.ib(default=DEFAULT_STEP)
     target = attr.ib(default="")
     instant = attr.ib(validator=instance_of(bool), default=False)
-    datasource = attr.ib(default="")
+    datasource = attr.ib(default=None)
 
     def to_json_data(self):
         return {


### PR DESCRIPTION
## What does this do?
Changes the default for target datasource

## Why is it a good idea?
The generated dashboard now works with newer versions of Grafana.

See:
https://github.com/weaveworks/grafanalib/issues/340
