### PR TITLE
Remove re-defined maxDataPoints from multiple panels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ x.x.x (TBD)
 ==================
 
 * Added ...
+* Added timeField field for the Elasticsearch target to allow the alert to change its state
+* Added nameFilter field for the AlertList panel
+* Added dashboardTags field for the AlertList panel
+* Added maxDataPoints field to the Stats panel
 
 
 Changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,6 @@ x.x.x (TBD)
 ==================
 
 * Added ...
-* Added timeField field for the Elasticsearch target to allow the alert to change its state
-* Added nameFilter field for the AlertList panel
-* Added dashboardTags field for the AlertList panel
-* Removed re-defined maxDataPoints field from multiple panels
 
 
 Changes
@@ -18,6 +14,7 @@ Changes
 * bugfix load_dashboard add support for old python version 2.x, 3.3 and 3.4 
 * Fix default target datasource to work with newer versions of Grafana
 * Added table-driven example dashboard and upload script
+* Removed re-defined maxDataPoints field from multiple panels
 
 
 0.5.11 (2021-04-06)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ x.x.x (TBD)
 * Added timeField field for the Elasticsearch target to allow the alert to change its state
 * Added nameFilter field for the AlertList panel
 * Added dashboardTags field for the AlertList panel
-* Added maxDataPoints field to the Stats panel
+* Removed re-defined maxDataPoints field from multiple panels
 
 
 Changes

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1581,7 +1581,6 @@ class Stat(Panel):
     thresholds = attr.ib(default="")
     reduceCalc = attr.ib(default='mean', type=str)
     decimals = attr.ib(default=None)
-    maxDataPoints = attr.ib(default=None)
 
     def to_json_data(self):
         return self.panel_json(
@@ -1613,7 +1612,6 @@ class Stat(Panel):
                     }
                 },
                 'type': STAT_TYPE,
-                'maxDataPoints': self.maxDataPoints
             }
         )
 
@@ -1724,8 +1722,6 @@ class SingleStat(Panel):
         Additional info can be found in docs:
         https://grafana.com/docs/grafana/latest/features/panels/singlestat/#value-to-text-mapping
     :param mappingTypes: the list of available mapping types for panel
-    :param maxDataPoints: maximum metric query results,
-        that will be used for rendering
     :param minSpan: minimum span number
     :param nullText: defines what to show if metric query result is undefined
     :param nullPointMode: defines how to render undefined values
@@ -1764,7 +1760,6 @@ class SingleStat(Panel):
             MAPPING_RANGE_TO_TEXT,
         ]),
     )
-    maxDataPoints = attr.ib(default=100)
     minSpan = attr.ib(default=None)
     nullText = attr.ib(default=None)
     nullPointMode = attr.ib(default='connected')
@@ -1796,7 +1791,6 @@ class SingleStat(Panel):
                 'hideTimeOverride': self.hideTimeOverride,
                 'mappingType': self.mappingType,
                 'mappingTypes': self.mappingTypes,
-                'maxDataPoints': self.maxDataPoints,
                 'minSpan': self.minSpan,
                 'nullPointMode': self.nullPointMode,
                 'nullText': self.nullText,
@@ -2098,8 +2092,6 @@ class BarGauge(Panel):
     :param limit: limit of number of values to show when not Calculating
     :param links: additional web links
     :param max: maximum value of the gauge
-    :param maxDataPoints: maximum metric query results,
-        that will be used for rendering
     :param min: minimum value of the gauge
     :param minSpan: minimum span number
     :param orientation: orientation of the bar gauge
@@ -2137,7 +2129,6 @@ class BarGauge(Panel):
     label = attr.ib(default=None)
     limit = attr.ib(default=None)
     max = attr.ib(default=100)
-    maxDataPoints = attr.ib(default=100)
     min = attr.ib(default=0)
     minSpan = attr.ib(default=None)
     orientation = attr.ib(
@@ -2164,7 +2155,6 @@ class BarGauge(Panel):
                 'cacheTimeout': self.cacheTimeout,
                 'hideTimeOverride': self.hideTimeOverride,
                 'interval': self.interval,
-                'maxDataPoints': self.maxDataPoints,
                 'minSpan': self.minSpan,
                 'options': {
                     'displayMode': self.displayMode,
@@ -2214,8 +2204,6 @@ class GaugePanel(Panel):
     :param limit: limit of number of values to show when not Calculating
     :param links: additional web links
     :param max: maximum value of the gauge
-    :param maxDataPoints: maximum metric query results,
-        that will be used for rendering
     :param min: minimum value of the gauge
     :param minSpan: minimum span number
     :param rangeMaps: the list of value to text mappings
@@ -2242,7 +2230,6 @@ class GaugePanel(Panel):
     label = attr.ib(default=None)
     limit = attr.ib(default=None)
     max = attr.ib(default=100)
-    maxDataPoints = attr.ib(default=100)
     min = attr.ib(default=0)
     minSpan = attr.ib(default=None)
     rangeMaps = attr.ib(default=attr.Factory(list))
@@ -2265,7 +2252,6 @@ class GaugePanel(Panel):
                 'cacheTimeout': self.cacheTimeout,
                 'hideTimeOverride': self.hideTimeOverride,
                 'interval': self.interval,
-                'maxDataPoints': self.maxDataPoints,
                 'minSpan': self.minSpan,
                 'options': {
                     'fieldOptions': {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1581,6 +1581,7 @@ class Stat(Panel):
     thresholds = attr.ib(default="")
     reduceCalc = attr.ib(default='mean', type=str)
     decimals = attr.ib(default=None)
+    maxDataPoints = attr.ib(default=None)
 
     def to_json_data(self):
         return self.panel_json(
@@ -1612,6 +1613,7 @@ class Stat(Panel):
                     }
                 },
                 'type': STAT_TYPE,
+                'maxDataPoints': self.maxDataPoints
             }
         )
 


### PR DESCRIPTION
## What does this do?
This PR removes the maxDataPoints field from multiple panels b/c it's inherited from Panel.
