### PR TITLE
Added 'hide' parameter to CloudwatchMetricsTarget class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changes
 * Added table-driven example dashboard and upload script
 * Removed re-defined maxDataPoints field from multiple panels
 * Fix the AlertList class and add a test for it
+* Added hide parameter to CloudwatchMetricsTarget class
 
 
 0.5.11 (2021-04-06)

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -40,7 +40,7 @@ class CloudwatchMetricsTarget(object):
     refId = attr.ib(default="")
     region = attr.ib(default="default")
     statistics = attr.ib(default=["Average"], validator=instance_of(list))
-    hide = attr.ib(default=False)
+    hide = attr.ib(default=False, validator=instance_of(bool))
 
     def to_json_data(self):
 

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -27,6 +27,7 @@ class CloudwatchMetricsTarget(object):
     :param refId: target reference id
     :param region: Cloudwatch region
     :param statistics: Cloudwatch mathematic statistic
+    :param hide: controls if given metric is displayed on visualization
     """
     alias = attr.ib(default="")
     dimensions = attr.ib(default={}, validator=instance_of(dict))
@@ -39,6 +40,7 @@ class CloudwatchMetricsTarget(object):
     refId = attr.ib(default="")
     region = attr.ib(default="default")
     statistics = attr.ib(default=["Average"], validator=instance_of(list))
+    hide = attr.ib(default=False)
 
     def to_json_data(self):
 
@@ -53,5 +55,6 @@ class CloudwatchMetricsTarget(object):
             "period": self.period,
             "refId": self.refId,
             "region": self.region,
-            "statistics": self.statistics
+            "statistics": self.statistics,
+            "hide": self.hide,
         }


### PR DESCRIPTION
## What does this do?
This PR adds 'hide' parameter to CloudwatchMetricsTarget class

## Why is it a good idea?
hide parameter is useful when you need to use a metric, but you don't want to display it. 

Note that 'hide' parameter is already defined for the `Target` class.

## Context
Example:
```
 Graph(
           # (...)
            targets=[
                CloudwatchMetricsTarget(
                    # (...)
                    metricName="SignInSuccesses",
                    namespace="AWS/Cognito",
                    alias="OK",
                    id="ok"
                ),
                CloudwatchMetricsTarget(
                    # (...)
                    metricName="SignInSuccesses",
                    namespace="AWS/Cognito",
                    id="total",
                    hide=True,
                ),
                CloudwatchMetricsTarget(
                    # (...)
                    id="failed",
                    expression="SUM([total, -ok])"
                ),
            ],
        ),
    ],
```

