### PR TITLE
Change 'target' attribute validator to a generic one in 'AlertCondition'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ x.x.x (TBD)
 Changes
 -------
 
-*
+* Bugfix: changed 'target' validator in AlertNotification to accept CloudwatchMetricsTarget
 
 0.5.12 (2021-04-24)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -371,6 +371,14 @@ class Repeat(object):
     maxPerRow = attr.ib(default=None, validator=is_valid_max_per_row)
 
 
+def is_valid_target(instance, attribute, value):
+    """
+    Check if a given attribute is a valid target
+    """
+    if not hasattr(value, "refId"):
+        raise ValueError(f"{attribute.name} should have 'refId' attribute")
+
+
 @attr.s
 class Target(object):
     """
@@ -920,7 +928,7 @@ class AlertCondition(object):
     :param type: CTYPE_*
     """
 
-    target = attr.ib(validator=instance_of(Target))
+    target = attr.ib(validator=is_valid_target)
     evaluator = attr.ib(validator=instance_of(Evaluator))
     timeRange = attr.ib(validator=instance_of(TimeRange))
     operator = attr.ib()


### PR DESCRIPTION
* Accept 'CloudwatchMetricsTarget' as target for 'AlertCondition'

## What does this do?
This PR changes 'target' attribute validator in AlertNotifications class

## Why is it a good idea?
I've encountered an issue where 'AlertNotifcation' class didn't accept CloudwatchMetricsTarget as target

## Questions
I've been considering creation of zope.interface.Interface and veryfing based on attrs.validators.provides, but this simple solution seems to be good enoguh for me