### PR TITLE
Move alertRuleTag from Graph to Alert.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,13 @@ Changelog
 x.x.x (TBD)
 ==================
 
-* Added ...
+* Added a test for the Alert class.
 
 Changes
 -------
 
 * Bugfix: changed 'target' validator in AlertNotification to accept CloudwatchMetricsTarget
+* Moved the alertRuleTag field from Graph to Alert.
 
 0.5.12 (2021-04-24)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -958,7 +958,9 @@ class AlertCondition(object):
 
 @attr.s
 class Alert(object):
-
+    """
+    :param alertRuleTags: Key Value pairs to be sent with Alert notifications.
+    """
     name = attr.ib()
     message = attr.ib()
     alertConditions = attr.ib()
@@ -968,6 +970,14 @@ class Alert(object):
     noDataState = attr.ib(default=STATE_NO_DATA)
     notifications = attr.ib(default=attr.Factory(list))
     gracePeriod = attr.ib(default='5m')
+    alertRuleTags = attr.ib(
+        default=attr.Factory(dict),
+        validator=attr.validators.deep_mapping(
+            key_validator=attr.validators.instance_of(str),
+            value_validator=attr.validators.instance_of(str),
+            mapping_validator=attr.validators.instance_of(dict),
+        )
+    )
 
     def to_json_data(self):
         return {
@@ -980,6 +990,7 @@ class Alert(object):
             'noDataState': self.noDataState,
             'notifications': self.notifications,
             'for': self.gracePeriod,
+            'alertRuleTags': self.alertRuleTags,
         }
 
 
@@ -1270,7 +1281,6 @@ class Graph(Panel):
     Generates Graph panel json structure.
 
     :param alert: List of AlertConditions
-    :param alertRuleTags: Key Value pairs to be sent with Alert notifications
     :param dataLinks: List of data links hooked to datapoints on the graph
     :param dataSource: DataSource's name
     :param minSpan: Minimum width for each panel
@@ -1278,7 +1288,6 @@ class Graph(Panel):
     """
 
     alert = attr.ib(default=None)
-    alertRuleTags = attr.ib(default=attr.Factory(dict))
     alertThreshold = attr.ib(default=True, validator=instance_of(bool))
     aliasColors = attr.ib(default=attr.Factory(dict))
     bars = attr.ib(default=False, validator=instance_of(bool))
@@ -1353,7 +1362,6 @@ class Graph(Panel):
         }
         if self.alert:
             graphObject['alert'] = self.alert
-            graphObject['alertRuleTags'] = self.alertRuleTags
             graphObject['thresholds'] = []
         if self.thresholds and self.alert:
             print("Warning: Graph threshold ignored as Alerts defined")
@@ -1511,7 +1519,8 @@ class AlertList(object):
             member_validator=attr.validators.instance_of(str),
             iterable_validator=attr.validators.instance_of(list)))
     description = attr.ib(default="", validator=instance_of(str))
-    gridPos = attr.ib(default=None, validator=instance_of(GridPos))
+    gridPos = attr.ib(
+        default=None, validator=attr.validators.optional(attr.validators.instance_of(GridPos)))
     id = attr.ib(default=None)
     limit = attr.ib(default=DEFAULT_LIMIT)
     links = attr.ib(

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -8,11 +8,33 @@ def dummy_grid_pos() -> G.GridPos:
     return G.GridPos(h=1, w=2, x=3, y=4)
 
 
-def dummy_data_link():
+def dummy_data_link() -> G.DataLink:
     return G.DataLink(
         title='dummy title',
         linkUrl='https://www.dummy-link-url.com',
         isNewTab=True
+    )
+
+
+def dummy_evaluator() -> G.Evaluator:
+    return G.Evaluator(
+        type=G.EVAL_GT,
+        params=42
+    )
+
+
+def dummy_alert_condition() -> G.AlertCondition:
+    return G.AlertCondition(
+        target=G.Target(),
+        evaluator=G.Evaluator(
+            type=G.EVAL_GT,
+            params=42),
+        timeRange=G.TimeRange(
+            from_time='5m',
+            to_time='now'
+        ),
+        operator=G.OP_AND,
+        reducerType=G.RTYPE_AVG,
     )
 
 
@@ -260,3 +282,13 @@ def test_alert_list():
         title='dummy title'
     )
     alert_list.to_json_data()
+
+
+def test_alert():
+    alert = G.Alert(
+        name='dummy name',
+        message='dummy message',
+        alertConditions=dummy_alert_condition(),
+        alertRuleTags=dict(alert_rul_dummy_key='alert rul dummy value')
+    )
+    alert.to_json_data()


### PR DESCRIPTION
## What does this do?
Move the alertRuleTags field from Graph to Alert.

## Why is it a good idea?
Because the dashboard extracts the alertRuleTags field from an alert mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/weaveworks/grafanalib/360)
<!-- Reviewable:end -->
