### PR TITLE
Add transformations field for the Panel class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x (TBD)
 ==================
 
-* Added ...
+* Added transformations for the Table panel (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options)
 
 Changes
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x (TBD)
 ==================
 
-* Added transformations for the Table panel (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options)
+* Added transformations for the Panel class (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options)
 
 Changes
 -------

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1142,6 +1142,7 @@ class Panel(object):
     :param timeFrom: time range that Override relative time
     :param title: of the panel
     :param transparent: defines if panel should be transparent
+    :param transformations: defines transformations applied to the table
     """
 
     dataSource = attr.ib(default=None)
@@ -1164,6 +1165,7 @@ class Panel(object):
     timeFrom = attr.ib(default=None)
     timeShift = attr.ib(default=None)
     transparent = attr.ib(default=False, validator=instance_of(bool))
+    transformations = attr.ib(default=attr.Factory(list), validator=instance_of(list))
 
     def _map_panels(self, f):
         return f(self)
@@ -1192,6 +1194,7 @@ class Panel(object):
             'timeShift': self.timeShift,
             'title': self.title,
             'transparent': self.transparent,
+            'transformations': self.transformations
         }
         res.update(overrides)
         return res
@@ -2020,7 +2023,6 @@ class Table(Panel):
     :param title: panel title
     :param transform: table style
     :param transparent: defines if panel should be transparent
-    :param transformations: defines transformations applied to the table
     """
 
     columns = attr.ib(default=attr.Factory(list))
@@ -2034,7 +2036,6 @@ class Table(Panel):
     sort = attr.ib(
         default=attr.Factory(ColumnSort), validator=instance_of(ColumnSort))
     styles = attr.ib()
-    transformations = attr.ib(default=attr.Factory(list), validator=instance_of(list))
 
     transform = attr.ib(default=COLUMNS_TRANSFORM)
 
@@ -2087,7 +2088,6 @@ class Table(Panel):
                 'styles': self.styles,
                 'transform': self.transform,
                 'type': TABLE_TYPE,
-                'transformations': self.transformations
             }
         )
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2020,6 +2020,7 @@ class Table(Panel):
     :param title: panel title
     :param transform: table style
     :param transparent: defines if panel should be transparent
+    :param transformations: defines transformations applied to the table
     """
 
     columns = attr.ib(default=attr.Factory(list))
@@ -2033,6 +2034,7 @@ class Table(Panel):
     sort = attr.ib(
         default=attr.Factory(ColumnSort), validator=instance_of(ColumnSort))
     styles = attr.ib()
+    transformations = attr.ib(default=list(), validator=instance_of(list))
 
     transform = attr.ib(default=COLUMNS_TRANSFORM)
 
@@ -2085,6 +2087,7 @@ class Table(Panel):
                 'styles': self.styles,
                 'transform': self.transform,
                 'type': TABLE_TYPE,
+                'transformations': self.transformations
             }
         )
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2034,7 +2034,7 @@ class Table(Panel):
     sort = attr.ib(
         default=attr.Factory(ColumnSort), validator=instance_of(ColumnSort))
     styles = attr.ib()
-    transformations = attr.ib(default=list(), validator=instance_of(list))
+    transformations = attr.ib(default=attr.Factory(list), validator=instance_of(list))
 
     transform = attr.ib(default=COLUMNS_TRANSFORM)
 

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -113,6 +113,33 @@ def test_table_styled_columns():
         G.ColumnStyle(pattern='Foo'),
     ]
 
+def test_table_transformations():
+    t = G.Table(
+        dataSource='some data source',
+        targets=[
+            G.Target(expr='some expr'),
+        ],
+        title='table title',
+        transformations = [
+                            {
+                                "id": "seriesToRows",
+                                "options": {}
+                            },
+                            {
+                                "id": "organize",
+                                "options": {
+                                    "excludeByName": {
+                                    "Time": True
+                                    },
+                                    "indexByName": {},
+                                    "renameByName": {
+                                    "Value": "Dummy"
+                                    }
+                            }
+                        }]
+    )
+    assert len(t.to_json_data()['transformations']) == 2
+    assert t.to_json_data()['transformations'][0]["id"] == "seriesToRows"
 
 def test_stat_no_repeat():
     t = G.Stat(

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -113,6 +113,7 @@ def test_table_styled_columns():
         G.ColumnStyle(pattern='Foo'),
     ]
 
+
 def test_table_transformations():
     t = G.Table(
         dataSource='some data source',
@@ -120,26 +121,28 @@ def test_table_transformations():
             G.Target(expr='some expr'),
         ],
         title='table title',
-        transformations = [
-                            {
-                                "id": "seriesToRows",
-                                "options": {}
-                            },
-                            {
-                                "id": "organize",
-                                "options": {
-                                    "excludeByName": {
-                                    "Time": True
-                                    },
-                                    "indexByName": {},
-                                    "renameByName": {
-                                    "Value": "Dummy"
-                                    }
-                            }
-                        }]
+        transformations=[
+            {
+                "id": "seriesToRows",
+                "options": {}
+            },
+            {
+                "id": "organize",
+                "options": {
+                    "excludeByName": {
+                        "Time": True
+                    },
+                    "indexByName": {},
+                    "renameByName": {
+                        "Value": "Dummy"
+                    }
+                }
+            }
+        ]
     )
     assert len(t.to_json_data()['transformations']) == 2
     assert t.to_json_data()['transformations'][0]["id"] == "seriesToRows"
+
 
 def test_stat_no_repeat():
     t = G.Stat(


### PR DESCRIPTION
## What does this do?
It's pretty straightforward code, which allows to add transformations (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options) for the Table panel. At the current moment, it just translate list of dicts with transformations to JSON as-is.

## Why is it a good idea?
I really miss this feature for the Tables. Adding transformations to the tables is very common pattern, which allows to increase readability and usability of Tables.