### PR TITLE
Add extraJson attribute to the Panel class for overriding the panel with raw JSON

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ x.x.x (TBD)
 * Added missing attributes from xAxis class
 * Added transformations for the Panel class (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options)
 * Added Worldmap panel (https://grafana.com/grafana/plugins/grafana-worldmap-panel/)
+* Added ``extraJson`` attribute to the Panel class for overriding the panel with raw JSON
 
 Changes
 -------

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1131,6 +1131,20 @@ class Dashboard(object):
         }
 
 
+def _deep_update(base_dict, extra_dict):
+    if extra_dict is None:
+        return base_dict
+
+    for k, v in extra_dict.items():
+        if k in base_dict and hasattr(base_dict[k], "to_json_data"):
+            base_dict[k] = base_dict[k].to_json_data()
+
+        if k in base_dict and isinstance(base_dict[k], dict):
+            _deep_update(base_dict[k], v)
+        else:
+            base_dict[k] = v
+
+
 @attr.s
 class Panel(object):
     """
@@ -1178,6 +1192,7 @@ class Panel(object):
     timeShift = attr.ib(default=None)
     transparent = attr.ib(default=False, validator=instance_of(bool))
     transformations = attr.ib(default=attr.Factory(list), validator=instance_of(list))
+    extraJson = attr.ib(default=None, validator=attr.validators.optional(instance_of(dict)))
 
     def _map_panels(self, f):
         return f(self)
@@ -1209,6 +1224,7 @@ class Panel(object):
             'transformations': self.transformations
         }
         res.update(overrides)
+        _deep_update(res, self.extraJson)
         return res
 
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1169,6 +1169,8 @@ class Panel(object):
     :param title: of the panel
     :param transparent: defines if panel should be transparent
     :param transformations: defines transformations applied to the table
+    :param extraJson: raw JSON additions or overrides added to the JSON output
+           of this panel, can be used for using unsupported features
     """
 
     dataSource = attr.ib(default=None)

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -232,6 +232,28 @@ def test_graph_panel():
     assert 'alert' not in data
 
 
+def test_panel_extra_json():
+    data_source = 'dummy data source'
+    targets = ['dummy_prom_query']
+    title = 'dummy title'
+    extraJson = {
+        'fillGradient': 6,
+        'yaxis': {'align': True},
+        'legend': {'avg': True},
+    }
+    graph = G.Graph(data_source, targets, title, extraJson=extraJson)
+    data = graph.to_json_data()
+    assert data['targets'] == targets
+    assert data['datasource'] == data_source
+    assert data['title'] == title
+    assert 'alert' not in data
+    assert data['fillGradient'] == 6
+    assert data['yaxis']['align'] is True
+    # Nested non-dict object should also be deep-updated
+    assert data['legend']['max'] is False
+    assert data['legend']['avg'] is True
+
+
 def test_graph_panel_threshold():
     data_source = 'dummy data source'
     targets = ['dummy_prom_query']


### PR DESCRIPTION
## What does this do?

This adds a new attribute called `extraJson` to the `Panel` class, enabling users to add attributes that are not currently supported by grafanalib, for example `fillGradient` and color mappings:

Example 1, a Graph with aligned y-axes and a fill gradient:

```py
Graph(
    title="...",
    dataSource=datasource,
    yAxes=YAxes(
        left=YAxis(format="bytes", min=None),
        right=YAxis(format="none", min=None),
    ),
    targets=[
        # ...
    ],
    extraJson={
        "yaxis": {"align": True},
        "fillGradient": 6
    }
)
```

Example 2, a pie chart with combining enabled and percentage shown in the legend:

```py
PieChart(
    title="..",
    dataSource=datasource,
    targets=[
        # ...
    ],
    pieType="donut",
    extraJson={
        "legend": {"percentage": True},
        "combine": {"label": "Others", "threshold": "0.01"}
    }
)
```

Other nice uses is for gradient color mappings:

- For `GaugePanel`:  

    ```py
        extraJson={"options": {"fieldOptions": {"defaults": {"color": {"mode": "continuous-GrYlRd"}}}}},
    ```
- For `Stat`: 

    ```py
        extraJson={"fieldConfig": {"defaults": {"color": {"mode": "continuous-GrYlRd"}}}},
    ```

Also supports adding options to nested objects, for example to a `Legend`. In the above example of a `PieChart`, if the user has already defined `legend=Legend(...)` and `extraJson` has an override for `legend`, the `Legend` object will first be converted using `to_json_data()` and then updated recursively.

## Why is it a good idea?

- Enables temporary support for Grafana features not yet supported by grafanalib
- Reduces users' boilerplate of manually patching the generated JSON output

Would temporarily help #379 #124 and possibly others

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
