### PR TITLE
Add inline script support for Elasticsearch metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ x.x.x (TBD)
 * Added missing align to graph panel
 * Added missing show percentage attribute to Pie chart panel
 * Added ``extraJson`` attribute to the Panel class for overriding the panel with raw JSON
+* Added inline script support for Elasticsearch metrics
 
 Changes
 -------

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -31,7 +31,7 @@ class CountMetricAgg(object):
         if self.inline:
             self.settings['script'] = {'inline': self.inline}
 
-       return {
+        return {
             'id': str(self.id),
             'hide': self.hide,
             'type': 'count',
@@ -103,7 +103,6 @@ class CardinalityMetricAgg(object):
             'inlineScript': self.inline,
             'settings': self.settings,
         }
-
 
 
 @attr.s
@@ -201,7 +200,6 @@ class SumMetricAgg(object):
             'inlineScript': self.inline,
             'settings': self.settings,
         }
-
 
 
 @attr.s

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -19,9 +19,11 @@ class CountMetricAgg(object):
     It's the default aggregator for elasticsearch queries.
     :param hide: show/hide the metric in the final panel display
     :param id: id of the metric
+    :param inline: script to apply to the data, using '_value'
     """
     id = attr.ib(default=0, validator=instance_of(int))
     hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
         return {
@@ -29,7 +31,12 @@ class CountMetricAgg(object):
             'hide': self.hide,
             'type': 'count',
             'field': 'select field',
-            'settings': {},
+            'inlineScript': self.inline,
+            'settings': {
+                'script': {
+                    'inline': self.inline
+                }
+            }
         }
 
 
@@ -42,18 +49,26 @@ class MaxMetricAgg(object):
     :param field: name of elasticsearch field to provide the maximum for
     :param hide: show/hide the metric in the final panel display
     :param id: id of the metric
+    :param inline: script to apply to the data, using '_value'
     """
     field = attr.ib(default="", validator=instance_of(str))
     id = attr.ib(default=0, validator=instance_of(int))
     hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
+        self.settings = {}
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
         return {
             'id': str(self.id),
             'hide': self.hide,
             'type': 'max',
             'field': self.field,
-            'settings': {},
+            'inlineScript': self.inline,
+            'settings': self.settings,
         }
 
 
@@ -66,19 +81,28 @@ class CardinalityMetricAgg(object):
     :param field: name of elasticsearch field to provide the maximum for
     :param id: id of the metric
     :param hide: show/hide the metric in the final panel display
+    :param inline: script to apply to the data, using '_value'
     """
     field = attr.ib(default="", validator=instance_of(str))
     id = attr.ib(default=0, validator=instance_of(int))
     hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
+        self.settings = {}
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
         return {
             'id': str(self.id),
             'hide': self.hide,
-            'type': 'cardinality',
+            'type': 'max',
             'field': self.field,
-            'settings': {},
+            'inlineScript': self.inline,
+            'settings': self.settings,
         }
+
 
 
 @attr.s
@@ -90,19 +114,27 @@ class AverageMetricAgg(object):
     :param field: name of elasticsearch field to provide the maximum for
     :param id: id of the metric
     :param hide: show/hide the metric in the final panel display
+    :param inline: script to apply to the data, using '_value'
     """
 
     field = attr.ib(default="", validator=instance_of(str))
     id = attr.ib(default=0, validator=instance_of(int))
     hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
+        self.settings = {}
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
         return {
             'id': str(self.id),
             'hide': self.hide,
-            'type': 'avg',
+            'type': 'max',
             'field': self.field,
-            'settings': {},
+            'inlineScript': self.inline,
+            'settings': self.settings,
             'meta': {}
         }
 
@@ -147,19 +179,28 @@ class SumMetricAgg(object):
     :param field: name of elasticsearch field to provide the sum over
     :param hide: show/hide the metric in the final panel display
     :param id: id of the metric
+    :param inline: script to apply to the data, using '_value'
     """
     field = attr.ib(default="", validator=instance_of(str))
     id = attr.ib(default=0, validator=instance_of(int))
     hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
+        self.settings = {}
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
         return {
-            'type': 'sum',
             'id': str(self.id),
             'hide': self.hide,
+            'type': 'max',
             'field': self.field,
-            'settings': {},
+            'inlineScript': self.inline,
+            'settings': self.settings,
         }
+
 
 
 @attr.s
@@ -221,6 +262,7 @@ class BucketScriptAgg(object):
             })
 
         return {
+            'field': 'select field',
             'type': 'bucket_script',
             'id': str(self.id),
             'hide': self.hide,

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -26,17 +26,18 @@ class CountMetricAgg(object):
     inline = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
-        return {
+        self.settings = {}
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
+       return {
             'id': str(self.id),
             'hide': self.hide,
             'type': 'count',
             'field': 'select field',
             'inlineScript': self.inline,
-            'settings': {
-                'script': {
-                    'inline': self.inline
-                }
-            }
+            'settings': self.settings,
         }
 
 
@@ -97,7 +98,7 @@ class CardinalityMetricAgg(object):
         return {
             'id': str(self.id),
             'hide': self.hide,
-            'type': 'max',
+            'type': 'cardinality',
             'field': self.field,
             'inlineScript': self.inline,
             'settings': self.settings,
@@ -131,7 +132,7 @@ class AverageMetricAgg(object):
         return {
             'id': str(self.id),
             'hide': self.hide,
-            'type': 'max',
+            'type': 'avg',
             'field': self.field,
             'inlineScript': self.inline,
             'settings': self.settings,
@@ -195,7 +196,7 @@ class SumMetricAgg(object):
         return {
             'id': str(self.id),
             'hide': self.hide,
-            'type': 'max',
+            'type': 'sum',
             'field': self.field,
             'inlineScript': self.inline,
             'settings': self.settings,


### PR DESCRIPTION

## What does this do?
This adds support for inline scripts to Elasticsearch metrics.

## Why is it a good idea?
Allows users to apply calculations to metrics directly

## Context
We have some metrics stored as Bytes/s but want to show them as bits/s, this patch allows the setting of inline to allows the calculation to be performed. 

With this patch, if inline is set then the output json looks something like 

`
 {  
   "field": "port_1_bytes",
   "hide": false,
   "id": "4", 
   "inlineScript": "_value*8",
   "meta": {}, 
   "settings": {  
        "script": { 
            "inline": "_value*8"
        }
     },
     "type": "max"
},        
`

If inline isn't set then we use:


`
 {  
   "field": "port_1_bytes",
   "hide": false,
   "id": "4", 
   "inlineScript": "_value*8",
   "meta": {}, 
   "settings": {},
     "type": "max"
},        
`


There is one additional change here, I found that for DateHistogramGroupBy, I had too add  'field': 'select field', to get this working.
