### PR TITLE
Added missing auto interval properties in Template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changes
 
 0.5.14 (2021-09-14)
 ==================
-
+* Added missing auto interval properties in Template
 * Added colour overrides to pie chart panel
 * Added missing attributes from xAxis class
 * Added transformations for the Panel class (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options)

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -489,7 +489,7 @@ class YAxis(object):
     label = attr.ib(default=None)
     logBase = attr.ib(default=1)
     max = attr.ib(default=None)
-    min = attr.ib(default=0)
+    min = attr.ib(default=None)
     show = attr.ib(default=True, validator=instance_of(bool))
 
     def to_json_data(self):

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -255,6 +255,8 @@ GAUGE_DISPLAY_MODE_BASIC = 'basic'
 GAUGE_DISPLAY_MODE_LCD = 'lcd'
 GAUGE_DISPLAY_MODE_GRADIENT = 'gradient'
 
+DEFAULT_AUTO_COUNT = 30
+DEFAULT_MIN_AUTO_INTERVAL = '10s'
 
 @attr.s
 class Mapping(object):
@@ -726,6 +728,9 @@ class Template(object):
         interval, datasource, custom, constant, adhoc.
     :param hide: Hide this variable in the dashboard, can be one of:
         SHOW (default), HIDE_LABEL, HIDE_VARIABLE
+    :param auto: Interval will be dynamically calculated by dividing time range by the count specified in auto_count.
+    :param autoCount: Number of intervals for dividing the time range.
+    :param autoMin: Smallest interval for auto interval generator.
     """
 
     name = attr.ib()
@@ -756,7 +761,16 @@ class Template(object):
     type = attr.ib(default='query')
     hide = attr.ib(default=SHOW)
     sort = attr.ib(default=SORT_ALPHA_ASC)
-
+    auto = attr.ib(
+        default=False,
+        validator=instance_of(bool),
+    )
+    autoCount = attr.ib(
+        default=DEFAULT_AUTO_COUNT,
+        validator=instance_of(int)
+    )
+    autoMin = attr.ib(default=DEFAULT_MIN_AUTO_INTERVAL)
+    
     def __attrs_post_init__(self):
         if self.type == 'custom':
             if len(self.options) == 0:
@@ -802,6 +816,9 @@ class Template(object):
             'useTags': self.useTags,
             'tagsQuery': self.tagsQuery,
             'tagValuesQuery': self.tagValuesQuery,
+            'auto': self.auto,
+            'auto_min': self.autoMin,
+            'auto_count': self.autoCount
         }
 
 


### PR DESCRIPTION
For the Template class, when the template type is interval is selected, the auto properties are missing.

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
