### PR TITLE
Do not default to 0 for min value for yAxes

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -487,7 +487,7 @@ class YAxis(object):
     label = attr.ib(default=None)
     logBase = attr.ib(default=1)
     max = attr.ib(default=None)
-    min = attr.ib(default=0)
+    min = attr.ib(default=None)
     show = attr.ib(default=True, validator=instance_of(bool))
 
     def to_json_data(self):


### PR DESCRIPTION
Setting 0 as default min value for yAxes is arbitrary and messes up all of Grafana's auto-scaling features. This commit sets the default to None and lets Grafana choose the min value. 
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
