### PR TITLE
Add color to StatMapping(s)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,16 @@ Changelog
 x.x.x (TBD)
 ===================
 
-* Added Discrete panel
+Added
+-----
+* Discrete panel
+* Support for colors in stat mapping panel with StatValueMappings & StatRangeMappings
 
 Changes
 -------
 
 * Changed Refine expectations of is_color_code
+* Deprecated StatMapping, StatValueMapping & StatRangeMapping
 
 0.5.14 (2021-09-14)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog
 x.x.x (TBD)
 ===================
 
-* Added ...
+* Added Discrete panel
 
 Changes
 -------
 
-* Changed ...
+* Changed Refine expectations of is_color_code
 
 0.5.14 (2021-09-14)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1,3 +1,4 @@
+
 """Low-level functions for building Grafana dashboards.
 
 The functions in this module don't enforce Weaveworks policy, and only mildly
@@ -1730,8 +1731,107 @@ class Stat(Panel):
 
 
 @attr.s
+class StatValueMappingItem(object):
+    """
+    Generates json structure for the value mapping item for the StatValueMappings class:
+
+    :param text: String that will replace input value
+    :param mapValue: Value to be replaced
+    :param color: How to color the text if mapping occurs
+    :param index: index
+    """
+
+    text = attr.ib()
+    mapValue = attr.ib(default="", validator=instance_of(str))
+    color = attr.ib(default="", validator=instance_of(str))
+    index = attr.ib(default=None)
+
+    def to_json_data(self):
+        return {
+            self.mapValue: {
+                'text': self.text,
+                'color': self.color,
+                'index': self.index
+            }
+        }
+
+
+@attr.s(init=False)
+class StatValueMappings(object):
+    """
+    Generates json structure for the value mappings for the StatPanel:
+
+    :param mappingItems: List of StatValueMappingItem objects
+
+    mappings=[
+        core.StatValueMappings(
+            core.StatValueMappingItem('Offline', '0', 'red'),  # Value must a string
+            core.StatValueMappingItem('Online', '1', 'green')
+        ),
+    ],
+    """
+
+    mappingItems = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(StatValueMappingItem),
+            iterable_validator=attr.validators.instance_of(list),
+        ),
+    )
+
+    def __init__(self, *mappings: StatValueMappingItem):
+        self.__attrs_init__([*mappings])
+
+    def to_json_data(self):
+        ret_dict = {
+            'type': 'value',
+            'options': {
+            }
+        }
+
+        for item in self.mappingItems:
+            ret_dict['options'].update(item.to_json_data())
+
+        return ret_dict
+
+
+@attr.s
+class StatRangeMappings(object):
+    """
+    Generates json structure for the range mappings for the StatPanel:
+
+    :param text: Sting that will replace input value
+    :param startValue: When using a range, the start value of the range
+    :param endValue: When using a range, the end value of the range
+    :param color: How to color the text if mapping occurs
+    :param index: index
+    """
+
+    text = attr.ib()
+    startValue = attr.ib(default=0, validator=instance_of(int))
+    endValue = attr.ib(default=0, validator=instance_of(int))
+    color = attr.ib(default="", validator=instance_of(str))
+    index = attr.ib(default=None)
+
+    def to_json_data(self):
+        return {
+            'type': 'range',
+            'options': {
+                'from': self.startValue,
+                'to': self.endValue,
+                'result': {
+                    'text': self.text,
+                    'color': self.color,
+                    'index': self.index
+                }
+            }
+        }
+
+
+@attr.s
 class StatMapping(object):
     """
+    Deprecated Grafana v8
     Generates json structure for the value mapping for the Stat panel:
 
     :param text: Sting that will replace input value
@@ -1750,7 +1850,7 @@ class StatMapping(object):
     def to_json_data(self):
         mappingType = MAPPING_TYPE_VALUE_TO_TEXT if self.mapValue else MAPPING_TYPE_RANGE_TO_TEXT
 
-        return {
+        ret_dict = {
             'operator': '',
             'text': self.text,
             'type': mappingType,
@@ -1760,14 +1860,17 @@ class StatMapping(object):
             'id': self.id
         }
 
+        return ret_dict
+
 
 @attr.s
 class StatValueMapping(object):
     """
+    Deprecated Grafana v8
     Generates json structure for the value mappings for the StatPanel:
 
     :param text: Sting that will replace input value
-    :param value: Value to be replaced
+    :param mapValue: Value to be replaced
     :param id: panel id
     """
 
@@ -1776,13 +1879,18 @@ class StatValueMapping(object):
     id = attr.ib(default=None)
 
     def to_json_data(self):
-        return StatMapping(self.text, mapValue=self.mapValue, id=self.id)
+        return StatMapping(
+            self.text,
+            mapValue=self.mapValue,
+            id=self.id,
+        )
 
 
 @attr.s
 class StatRangeMapping(object):
     """
-    Generates json structure for the value mappings for the StatPanel:
+    Deprecated Grafana v8
+    Generates json structure for the range mappings for the StatPanel:
 
     :param text: Sting that will replace input value
     :param startValue: When using a range, the start value of the range

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1452,6 +1452,7 @@ class Graph(Panel):
 
         def set_refid(t):
             return t if t.refId else attr.evolve(t, refId=next(auto_ref_ids))
+
         return self._map_targets(set_refid)
 
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -76,6 +76,7 @@ ABSOLUTE_TYPE = 'absolute'
 DASHBOARD_TYPE = 'dashboard'
 ROW_TYPE = 'row'
 GRAPH_TYPE = 'graph'
+DISCRETE_TYPE = 'natel-discrete-panel'
 STAT_TYPE = 'stat'
 SINGLESTAT_TYPE = 'singlestat'
 TABLE_TYPE = 'table'
@@ -1454,6 +1455,53 @@ class Graph(Panel):
             return t if t.refId else attr.evolve(t, refId=next(auto_ref_ids))
 
         return self._map_targets(set_refid)
+
+
+@attr.s
+class DiscreteColorMappingItem(object):
+    """
+    Generates json structure for the value mapping item for the StatValueMappings class:
+
+    :param text: String to color
+    :param color: To color the text with
+    """
+
+    text = attr.ib(validator=instance_of(str))
+    color = attr.ib(default=GREY1, validator=instance_of((str, RGBA)))
+
+    def to_json_data(self):
+        return {
+            "color": self.color,
+            "text": self.text,
+        }
+
+
+@attr.s
+class Discrete(Panel):
+    """
+    Generates Discrete panel json structure.
+
+    :param colorMaps: List of DiscreteColorMappingItem, to color values.
+    """
+
+    colorMapsItems = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(DiscreteColorMappingItem),
+            iterable_validator=attr.validators.instance_of(list),
+        ),
+    )
+
+    def to_json_data(self):
+        graphObject = {
+            'colorMaps': self.colorMapsItems,
+            'datasource': self.dataSource,
+            'grid': self.gridPos,
+            'targets': self.targets,
+            'title': self.title,
+            'type': DISCRETE_TYPE,
+        }
+        return self.panel_json(graphObject)
 
 
 @attr.s

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -159,6 +159,44 @@ def test_stat_no_repeat():
     assert t.to_json_data()['maxPerRow'] is None
 
 
+def test_StatValueMappings_exception_checks():
+    with pytest.raises(TypeError):
+        G.StatValueMappings(
+            G.StatValueMappingItem('foo', '0', 'dark-red'),
+            "not of type StatValueMappingItem",
+        )
+
+
+def test_StatValueMappings():
+    t = G.StatValueMappings(
+        G.StatValueMappingItem('foo', '0', 'dark-red'),  # Value must a string
+        G.StatValueMappingItem('bar', '1', 'purple'),
+    )
+
+    json_data = t.to_json_data()
+    assert json_data['type'] == 'value'
+    assert json_data['options']['0']['text'] == 'foo'
+    assert json_data['options']['0']['color'] == 'dark-red'
+    assert json_data['options']['1']['text'] == 'bar'
+    assert json_data['options']['1']['color'] == 'purple'
+
+
+def test_StatRangeMappings():
+    t = G.StatRangeMappings(
+        'dummy_text',
+        startValue=10,
+        endValue=20,
+        color='dark-red'
+    )
+
+    json_data = t.to_json_data()
+    assert json_data['type'] == 'range'
+    assert json_data['options']['from'] == 10
+    assert json_data['options']['to'] == 20
+    assert json_data['options']['result']['text'] == 'dummy_text'
+    assert json_data['options']['result']['color'] == 'dark-red'
+
+
 def test_DiscreteColorMappingItem_exception_checks():
     with pytest.raises(TypeError):
         G.DiscreteColorMappingItem(123)
@@ -193,6 +231,19 @@ def test_Discrete():
     assert json_data['colorMaps'] == colorMap
     assert json_data['title'] == ''
     assert json_data['type'] == G.DISCRETE_TYPE
+
+
+def test_StatMapping():
+    t = G.StatMapping(
+        'dummy_text',
+        startValue='foo',
+        endValue='bar',
+    )
+
+    json_data = t.to_json_data()
+    assert json_data['text'] == 'dummy_text'
+    assert json_data['from'] == 'foo'
+    assert json_data['to'] == 'bar'
 
 
 def test_stat_with_repeat():

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -225,11 +225,11 @@ def test_Discrete():
         G.DiscreteColorMappingItem('foz', color='faz')
     ]
 
-    t = G.Discrete('foo', colorMapsItems=colorMap)
+    t = G.Discrete(title='foo', colorMapsItems=colorMap)
 
     json_data = t.to_json_data()
     assert json_data['colorMaps'] == colorMap
-    assert json_data['title'] == ''
+    assert json_data['title'] == 'foo'
     assert json_data['type'] == G.DISCRETE_TYPE
 
 

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -2,6 +2,7 @@
 
 import random
 import grafanalib.core as G
+import pytest
 
 
 def dummy_grid_pos() -> G.GridPos:
@@ -156,6 +157,42 @@ def test_stat_no_repeat():
     assert t.to_json_data()['repeat'] is None
     assert t.to_json_data()['repeatDirection'] is None
     assert t.to_json_data()['maxPerRow'] is None
+
+
+def test_DiscreteColorMappingItem_exception_checks():
+    with pytest.raises(TypeError):
+        G.DiscreteColorMappingItem(123)
+
+    with pytest.raises(TypeError):
+        G.DiscreteColorMappingItem("foo", color=123)
+
+
+def test_DiscreteColorMappingItem():
+    t = G.DiscreteColorMappingItem('foo')
+
+    json_data = t.to_json_data()
+    assert json_data['text'] == 'foo'
+    assert json_data['color'] == G.GREY1
+
+    t = G.DiscreteColorMappingItem('foo', color='bar')
+
+    json_data = t.to_json_data()
+    assert json_data['text'] == 'foo'
+    assert json_data['color'] == 'bar'
+
+
+def test_Discrete():
+    colorMap = [
+        G.DiscreteColorMappingItem('bar', color='baz'),
+        G.DiscreteColorMappingItem('foz', color='faz')
+    ]
+
+    t = G.Discrete('foo', colorMapsItems=colorMap)
+
+    json_data = t.to_json_data()
+    assert json_data['colorMaps'] == colorMap
+    assert json_data['title'] == ''
+    assert json_data['type'] == G.DISCRETE_TYPE
 
 
 def test_stat_with_repeat():

--- a/grafanalib/validators.py
+++ b/grafanalib/validators.py
@@ -47,7 +47,7 @@ def is_color_code(instance, attribute, value):
     Value considered as valid color code if it starts with # char
     followed by hexadecimal.
     """
-    err = "{attr} should be a valid color code".format(attr=attribute.name)
+    err = "{attr} should be a valid color code (e.g. #37872D)".format(attr=attribute.name)
     if not value.startswith("#"):
         raise ValueError(err)
     if len(value) != 7:


### PR DESCRIPTION
## What does this do?
Adds color option for StatMapping(s).

## Why is it a good idea?
To be able to change the color while mapping.

## Questions
I added the color on the same (dict) level as the text ("OFF") key:
![image](https://user-images.githubusercontent.com/9251021/134564142-35a0c49a-7852-437a-8dfd-bba91b00a878.png)
but the color does not seem to end up in the correct space (it does not appear at all :/).
