### PR TITLE
Add support for ImageIt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ test-results/junit-*.xml
 .ensure-*
 /.tox
 /.coverage
+/venv/
+/.idea/
 
 # Documentation
 docs/build

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,16 +7,18 @@ x.x.x (TBD)
 
 * Added Discrete panel
 * Added support for colors in stat mapping panel with StatValueMappings & StatRangeMappings
+* Added missing auto interval properties in Template
 
 Changes
 -------
 
 * Refine expectations of is_color_code
 * Deprecated StatMapping, StatValueMapping & StatRangeMapping
+* Change YAxis min value default from None to 0
 
 0.5.14 (2021-09-14)
 ==================
-* Added missing auto interval properties in Template
+
 * Added colour overrides to pie chart panel
 * Added missing attributes from xAxis class
 * Added transformations for the Panel class (https://grafana.com/docs/grafana/next/panels/transformations/types-options/#transformation-types-and-options)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changes
 
 * Refine expectations of is_color_code
 * Deprecated StatMapping, StatValueMapping & StatRangeMapping
-* Change YAxis min value default from None to 0
+* Change YAxis min value default from 0 to None
 
 0.5.14 (2021-09-14)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ x.x.x (TBD)
 Changes
 -------
 
+* Fix Text panel (and add tests)
 * Refine expectations of is_color_code
 * Deprecated StatMapping, StatValueMapping & StatRangeMapping
 * Change YAxis min value default from 0 to None

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ Changelog
 x.x.x (TBD)
 ===================
 
-* Added Discrete panel
+* Added ImageIt panel (https://grafana.com/grafana/plugins/pierosavi-imageit-panel/)
+* Added Discrete panel (https://grafana.com/grafana/plugins/natel-discrete-panel/)
 * Added support for colors in stat mapping panel with StatValueMappings & StatRangeMappings
 * Added missing auto interval properties in Template
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,17 +5,21 @@ Changelog
 0.6.1 (TBD)
 ==================
 
+* Added ImageIt panel (https://grafana.com/grafana/plugins/pierosavi-imageit-panel/)
 * Added new SqlTarget to core to be able to define SQL queries as well
 * Added missing attributes to the Logs panel
 * Added Cloudwatch Logs Insights Target
 * Added overrides to panels
 * Extend ``SeriesOverride`` options
 
+Changes
+-------
+
+* Fix Text panel (and add tests)
 
 0.6.0 (2021-10-26)
 ===================
 
-* Added ImageIt panel (https://grafana.com/grafana/plugins/pierosavi-imageit-panel/)
 * Added Discrete panel (https://grafana.com/grafana/plugins/natel-discrete-panel/)
 * Added support for colors in stat mapping panel with StatValueMappings & StatRangeMappings
 * Added missing auto interval properties in Template
@@ -29,7 +33,6 @@ Changelog
 Changes
 -------
 
-* Fix Text panel (and add tests)
 * Refine expectations of is_color_code
 * Deprecated StatMapping, StatValueMapping & StatRangeMapping
 * Change YAxis min value default from 0 to None

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -260,6 +260,7 @@ GAUGE_DISPLAY_MODE_GRADIENT = 'gradient'
 DEFAULT_AUTO_COUNT = 30
 DEFAULT_MIN_AUTO_INTERVAL = '10s'
 
+
 @attr.s
 class Mapping(object):
 
@@ -772,7 +773,7 @@ class Template(object):
         validator=instance_of(int)
     )
     autoMin = attr.ib(default=DEFAULT_MIN_AUTO_INTERVAL)
-    
+
     def __attrs_post_init__(self):
         if self.type == 'custom':
             if len(self.options) == 0:

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1477,46 +1477,24 @@ class Graph(Panel):
 
 
 @attr.s
-class DiscreteColorMappingItem(object):
+class ValueMap(object):
     """
-    Generates json structure for the value mapping item for the StatValueMappings class:
+    Generates json structure for a value mapping item.
 
-    :param text: String to color
-    :param color: To color the text with
+    :param op: comparison operator
+    :param value: value to map to text
+    :param text: text to map the value to
     """
-
-    text = attr.ib(validator=instance_of(str))
-    color = attr.ib(default=GREY1, validator=instance_of((str, RGBA)))
+    text = attr.ib()
+    value = attr.ib()
+    op = attr.ib(default='=')
 
     def to_json_data(self):
         return {
-            "color": self.color,
-            "text": self.text,
+            'op': self.op,
+            'text': self.text,
+            'value': self.value,
         }
-
-
-@attr.s
-class Discrete(Panel):
-    """
-    Generates Discrete panel json structure.
-
-    :param colorMaps: List of DiscreteColorMappingItem, to color values.
-    """
-
-    colorMapsItems = attr.ib(
-        default=[],
-        validator=attr.validators.deep_iterable(
-            member_validator=attr.validators.instance_of(DiscreteColorMappingItem),
-            iterable_validator=attr.validators.instance_of(list),
-        ),
-    )
-
-    def to_json_data(self):
-        graphObject = {
-            'colorMaps': self.colorMapsItems,
-            'type': DISCRETE_TYPE,
-        }
-        return self.panel_json(graphObject)
 
 
 @attr.s
@@ -1542,16 +1520,21 @@ class SparkLine(object):
 
 
 @attr.s
-class ValueMap(object):
-    op = attr.ib()
-    text = attr.ib()
-    value = attr.ib()
+class Gauge(object):
+
+    minValue = attr.ib(default=0, validator=instance_of(int))
+    maxValue = attr.ib(default=100, validator=instance_of(int))
+    show = attr.ib(default=False, validator=instance_of(bool))
+    thresholdLabels = attr.ib(default=False, validator=instance_of(bool))
+    thresholdMarkers = attr.ib(default=True, validator=instance_of(bool))
 
     def to_json_data(self):
         return {
-            'op': self.op,
-            'text': self.text,
-            'value': self.value,
+            'maxValue': self.maxValue,
+            'minValue': self.minValue,
+            'show': self.show,
+            'thresholdLabels': self.thresholdLabels,
+            'thresholdMarkers': self.thresholdMarkers,
         }
 
 
@@ -1570,22 +1553,176 @@ class RangeMap(object):
 
 
 @attr.s
-class Gauge(object):
+class DiscreteColorMappingItem(object):
+    """
+    Generates json structure for the value mapping item for the StatValueMappings class:
 
-    minValue = attr.ib(default=0, validator=instance_of(int))
-    maxValue = attr.ib(default=100, validator=instance_of(int))
-    show = attr.ib(default=False, validator=instance_of(bool))
-    thresholdLabels = attr.ib(default=False, validator=instance_of(bool))
-    thresholdMarkers = attr.ib(default=True, validator=instance_of(bool))
+    :param text: String to color
+    :param color: To color the text with
+    """
+
+    text = attr.ib(validator=instance_of(str))
+    color = attr.ib(default=GREY1, validator=instance_of((str, RGBA)))
 
     def to_json_data(self):
         return {
-            'maxValue': self.maxValue,
-            'minValue': self.minValue,
-            'show': self.show,
-            'thresholdLabels': self.thresholdLabels,
-            'thresholdMarkers': self.thresholdMarkers,
+            "color": self.color,
+            "text": self.text,
         }
+
+
+@attr.s
+class Discrete(Panel):
+    """
+    Generates Discrete panel json structure.
+    https://grafana.com/grafana/plugins/natel-discrete-panel/
+
+    :param colorMaps: list of DiscreteColorMappingItem, to color values
+        (note these apply **after** value mappings)
+    :param backgroundColor: dito
+    :param lineColor: Separator line color between rows
+    :param metricNameColor: dito
+    :param timeTextColor: dito
+    :param valueTextColor: dito
+
+    :param decimals: number of decimals to display
+    :param rowHeight: dito
+
+    :param units: defines value units
+    :param legendSortBy: time (desc: '-ms', asc: 'ms), count (desc: '-count', asc: 'count')
+
+    :param highlightOnMouseover: whether to highlight the state of hovered time falls in.
+    :param showLegend: dito
+    :param showLegendPercent: whether to show percentage of time spent in each state/value
+    :param showLegendNames:
+    :param showLegendValues: whether to values in legend
+    :param legendPercentDecimals: number of decimals for legend
+    :param showTimeAxis: dito
+    :param use12HourClock: dito
+    :param writeMetricNames: dito
+    :param writeLastValue: dito
+    :param writeAllValues: whether to show all values
+
+    :param showDistinctCount: whether to show distinct values count
+    :param showLegendCounts: whether to show value occurrence count
+    :param showLegendTime: whether to show of each state
+    :param showTransitionCount: whether to show transition count
+
+    :param colorMaps: list of DiscreteColorMappingItem
+    :param rangeMaps: list of RangeMap
+    :param valueMaps: list of ValueMap
+    """
+
+    backgroundColor = attr.ib(
+        default=RGBA(128, 128, 128, 0.1),
+        validator=instance_of((RGBA, RGB, str))
+    )
+    lineColor = attr.ib(
+        default=RGBA(0, 0, 0, 0.1),
+        validator=instance_of((RGBA, RGB, str))
+    )
+    metricNameColor = attr.ib(
+        default="#000000",
+        validator=instance_of((RGBA, RGB, str))
+    )
+    timeTextColor = attr.ib(
+        default="#d8d9da",
+        validator=instance_of((RGBA, RGB, str))
+    )
+    valueTextColor = attr.ib(
+        default="#000000",
+        validator=instance_of((RGBA, RGB, str))
+    )
+
+    decimals = attr.ib(default=0, validator=instance_of(int))
+    legendPercentDecimals = attr.ib(default=0, validator=instance_of(int))
+    rowHeight = attr.ib(default=50, validator=instance_of(int))
+    textSize = attr.ib(default=24, validator=instance_of(int))
+
+    textSizeTime = attr.ib(default=12, validator=instance_of(int))
+    units = attr.ib(default="none", validator=instance_of(str))
+    legendSortBy = attr.ib(
+        default="-ms",
+        validator=in_(['-ms', 'ms', '-count', 'count'])
+    )
+
+    highlightOnMouseover = attr.ib(default=True, validator=instance_of(bool))
+    showLegend = attr.ib(default=True, validator=instance_of(bool))
+    showLegendPercent = attr.ib(default=True, validator=instance_of(bool))
+    showLegendNames = attr.ib(default=True, validator=instance_of(bool))
+    showLegendValues = attr.ib(default=True, validator=instance_of(bool))
+    showTimeAxis = attr.ib(default=True, validator=instance_of(bool))
+    use12HourClock = attr.ib(default=False, validator=instance_of(bool))
+    writeMetricNames = attr.ib(default=False, validator=instance_of(bool))
+    writeLastValue = attr.ib(default=True, validator=instance_of(bool))
+    writeAllValues = attr.ib(default=False, validator=instance_of(bool))
+
+    showDistinctCount = attr.ib(default=None)
+    showLegendCounts = attr.ib(default=None)
+    showLegendTime = attr.ib(default=None)
+    showTransitionCount = attr.ib(default=None)
+
+    colorMaps = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=instance_of(DiscreteColorMappingItem),
+            iterable_validator=instance_of(list),
+        ),
+    )
+    rangeMaps = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=instance_of(RangeMap),
+            iterable_validator=instance_of(list),
+        ),
+    )
+    valueMaps = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=instance_of(ValueMap),
+            iterable_validator=instance_of(list),
+        ),
+    )
+
+    def to_json_data(self):
+        graphObject = {
+            'type': DISCRETE_TYPE,
+
+            'backgroundColor': self.backgroundColor,
+            'lineColor': self.lineColor,
+            'metricNameColor': self.metricNameColor,
+            'timeTextColor': self.timeTextColor,
+            'valueTextColor': self.valueTextColor,
+            'legendPercentDecimals': self.legendPercentDecimals,
+            'decimals': self.decimals,
+            'rowHeight': self.rowHeight,
+            'textSize': self.textSize,
+            'textSizeTime': self.textSizeTime,
+
+            'units': self.units,
+            'legendSortBy': self.legendSortBy,
+
+            'highlightOnMouseover': self.highlightOnMouseover,
+            'showLegend': self.showLegend,
+            'showLegendPercent': self.showLegendPercent,
+            'showLegendNames': self.showLegendNames,
+            'showLegendValues': self.showLegendValues,
+            'showTimeAxis': self.showTimeAxis,
+            'use12HourClock': self.use12HourClock,
+            'writeMetricNames': self.writeMetricNames,
+            'writeLastValue': self.writeLastValue,
+            'writeAllValues': self.writeAllValues,
+
+            'showDistinctCount': self.showDistinctCount,
+            'showLegendCounts': self.showLegendCounts,
+            'showLegendTime': self.showLegendTime,
+            'showTransitionCount': self.showTransitionCount,
+
+            'colorMaps': self.colorMaps,
+            'rangeMaps': self.rangeMaps,
+            'valueMaps': self.valueMaps,
+        }
+        return self.panel_json(graphObject)
 
 
 @attr.s

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1868,8 +1868,8 @@ class ImageItMapping:
     overrideValue = attr.ib(default="", validator=instance_of(str))
 
     operator = attr.ib(
-        default="=",
-        validator=in_(['=', '!=', '<', '>']),
+        default="equal",
+        validator=in_(['equal', 'notEqual', 'smallerThan', 'greaterThan']),
     )
 
     id = attr.ib(

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1756,7 +1756,7 @@ class ImageItSensor:
     valueBlink = attr.ib(default=False, validator=instance_of(bool))
     visible = attr.ib(default=True, validator=instance_of(bool))
 
-    decimals = attr.ib(default=0, validator=instance_of(int))
+    decimals = attr.ib(default=2, validator=instance_of(int))
 
     name = attr.ib(default="", validator=instance_of(str))
     imageUrl = attr.ib(default="", validator=instance_of(str))
@@ -1772,16 +1772,16 @@ class ImageItSensor:
     )
 
     backgroundColor = attr.ib(
-        default=False,
+        default='#000',
         validator=instance_of((RGBA, RGB, str))
     )
     fontColor = attr.ib(
-        default=False,
+        default='#FFF',
         validator=instance_of((RGBA, RGB, str))
     )
 
     def to_json_data(self):
-        return self.panel_json({
+        return {
             'backgroundBlink': self.backgroundBlink,    # false
             'backgroundColor': self.backgroundColor,    # "#000"
             'bold': self.bold,    # false
@@ -1790,11 +1790,11 @@ class ImageItSensor:
             'link': self.link,    # ""
             'mappingIds': self.mappingIds,    # []
             'name': self.name,    # "Name"
-            "position": {*self.position},
+            "position": self.position,
             'query': self.query,
             'valueBlink': self.valueBlink,    # false
-            "visible": self.visible,    # true
-        })
+            'visible': self.visible,    # true
+        }
 
 
 @attr.s
@@ -1831,7 +1831,6 @@ class ImageIt(Panel):
     def to_json_data(self):
         return self.panel_json({
             'type': IMAGEIT_TYPE,
-            # 'transformations': self.transformations,
             'options': {
                 'forceImageRefresh': self.forceImageRefresh,
                 'imageUrl': self.imageUrl,

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1832,6 +1832,7 @@ class ImageItSensor:
             'link': self.link,    # ""
             'mappingIds': self.mappingIds,    # []
             'name': self.name,    # "Name"
+            'unit': self.unit,
             "position": self.position,
             'query': self.query,
             'valueBlink': self.valueBlink,    # false

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1752,6 +1752,9 @@ class Discrete(Panel):
 class ImageItSensorQuery:
     """
     ImageIt sensor query
+
+    :param alias:
+    :param id:
     """
 
     alias = attr.ib(default='', validator=instance_of(str))
@@ -1768,6 +1771,20 @@ class ImageItSensorQuery:
 class ImageItSensor:
     """
     ImageIt sensor.
+
+    :param backgroundBlink:
+    :param bold:
+    :param valueBlink:
+    :param visible:
+    :param decimals:
+    :param name:
+    :param link:
+    :param unit:
+    :param mappingIds:
+    :param position:
+    :param query:
+    :param backgroundColor:
+    :param fontColor:
     """
 
     backgroundBlink = attr.ib(default=False, validator=instance_of(bool))
@@ -1820,6 +1837,18 @@ class ImageItSensor:
 class ImageItMapping:
     """
     ImageItMapping
+
+    :param backgroundBlink:
+    :param bold:
+    :param valueBlink:
+    :param visible:
+    :param compareTo:
+    :param description:
+    :param overrideValue:
+    :param operator:
+    :param id:
+    :param backgroundColor:
+    :param fontColor:
     """
 
     backgroundBlink = attr.ib(default=False, validator=instance_of(bool))
@@ -1870,9 +1899,19 @@ class ImageItMapping:
 
 @attr.s
 class ImageIt(Panel):
-    """Generates a Text panel."""
+    """
+    Generates a ImageIt panel. See:
+    https://grafana.com/grafana/plugins/pierosavi-imageit-panel/ for details.
 
-    forceImageRefresh = attr.ib(default=True, validator=instance_of(bool))
+    :param forceImageRefresh:
+    :param lockSensors:
+    :param imageUrl:
+    :param sensorsTextSize:
+    :param mappings:
+    :param sensors:
+    """
+
+    forceImageRefresh = attr.ib(default=False, validator=instance_of(bool))
     lockSensors = attr.ib(default=False, validator=instance_of(bool))
 
     imageUrl = attr.ib(default="", validator=instance_of(str))

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1729,19 +1729,22 @@ class Discrete(Panel):
 class Text(Panel):
     """Generates a Text panel."""
 
-    content = attr.ib(default="")
+    content = attr.ib(default="", validator=instance_of(str))
     error = attr.ib(default=False, validator=instance_of(bool))
-    mode = attr.ib(default=TEXT_MODE_MARKDOWN)
+    mode = attr.ib(
+        default=TEXT_MODE_MARKDOWN,
+        validator=in_([TEXT_MODE_MARKDOWN, TEXT_MODE_HTML, TEXT_MODE_TEXT])
+    )
 
     def to_json_data(self):
-        return self.panel_json(
-            {
+        return self.panel_json({
+            'type': TEXT_TYPE,
+            'error': self.error,
+            'options': {
                 'content': self.content,
-                'error': self.error,
                 'mode': self.mode,
-                'type': TEXT_TYPE,
-            }
-        )
+            },
+        })
 
 
 @attr.s

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -9,6 +9,7 @@ arbitrary Grafana JSON.
 import itertools
 import math
 
+import random
 import string
 import warnings
 from numbers import Number
@@ -1799,7 +1800,54 @@ class ImageItSensor:
 
 @attr.s
 class ImageItMapping:
-    pass
+    """
+    ImageItMapping
+    """
+
+    backgroundBlink = attr.ib(default=False, validator=instance_of(bool))
+    bold = attr.ib(default=False, validator=instance_of(bool))
+    valueBlink = attr.ib(default=False, validator=instance_of(bool))
+    visible = attr.ib(default=True, validator=instance_of(bool))
+
+    compareTo = attr.ib(default="", validator=instance_of(str))
+    description = attr.ib(default="", validator=instance_of(str))
+    overrideValue = attr.ib(default="", validator=instance_of(str))
+
+    operator = attr.ib(
+        default="=",
+        validator=in_(['=', '!=', '<', '>']),
+    )
+
+    id = attr.ib(
+        default=f'mapping_{"".join(random.choices(string.ascii_lowercase + string.digits, k=6))}',
+        validator=instance_of(str)
+    )
+
+    backgroundColor = attr.ib(
+        default='#000',
+        validator=instance_of((RGBA, RGB, str))
+    )
+    fontColor = attr.ib(
+        default='#FFF',
+        validator=instance_of((RGBA, RGB, str))
+    )
+
+    def to_json_data(self):
+        return {
+            'compareTo': self.compareTo,
+            'description': self.description,
+            'id': self.id,
+            'operator': self.operator,
+            'values': {
+                'backgroundBlink': self.backgroundBlink,
+                'backgroundColor': self.backgroundColor,
+                'bold': self.bold,
+                'fontColor': self.fontColor,
+                'overrideValue': self.overrideValue,
+                'valueBlink': self.valueBlink,
+                'visible': self.visible,
+            }
+        }
 
 
 @attr.s

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -15,6 +15,7 @@ from numbers import Number
 
 import attr
 from attr.validators import in_, instance_of
+from collections import namedtuple
 
 
 @attr.s
@@ -92,6 +93,7 @@ STATUSMAP_TYPE = 'flant-statusmap-panel'
 SVG_TYPE = 'marcuscalidus-svg-panel'
 PIE_CHART_TYPE = 'grafana-piechart-panel'
 WORLD_MAP_TYPE = 'grafana-worldmap-panel'
+IMAGEIT_TYPE = 'pierosavi-imageit-panel'
 
 DEFAULT_FILL = 1
 DEFAULT_REFRESH = '10s'
@@ -292,6 +294,8 @@ VTYPE_FIRST = 'first'
 VTYPE_DELTA = 'delta'
 VTYPE_RANGE = 'range'
 VTYPE_DEFAULT = VTYPE_AVG
+
+Point2D = namedtuple('Point2D', 'x,y')
 
 
 @attr.s
@@ -1723,6 +1727,120 @@ class Discrete(Panel):
             'valueMaps': self.valueMaps,
         }
         return self.panel_json(graphObject)
+
+
+@attr.s
+class ImageItSensorQuery:
+    """
+    ImageIt sensor query
+    """
+
+    alias = attr.ib(default='', validator=instance_of(str))
+    id = attr.ib(default='', validator=instance_of(str))
+
+    def to_json_data(self):
+        return {
+            'alias': self.alias,
+            'id': self.id,
+        }
+
+
+@attr.s
+class ImageItSensor:
+    """
+    ImageIt sensor.
+    """
+
+    backgroundBlink = attr.ib(default=False, validator=instance_of(bool))
+    bold = attr.ib(default=False, validator=instance_of(bool))
+    valueBlink = attr.ib(default=False, validator=instance_of(bool))
+    visible = attr.ib(default=True, validator=instance_of(bool))
+
+    decimals = attr.ib(default=0, validator=instance_of(int))
+
+    name = attr.ib(default="", validator=instance_of(str))
+    imageUrl = attr.ib(default="", validator=instance_of(str))
+    link = attr.ib(default="", validator=instance_of(str))
+
+    mappingIds = attr.ib(default=[], validator=instance_of(list))
+
+    position = attr.ib(default=Point2D(0, 0), validator=instance_of(Point2D))
+
+    query = attr.ib(
+        default=ImageItSensorQuery(id='', alias=''),
+        validator=instance_of(ImageItSensorQuery)
+    )
+
+    backgroundColor = attr.ib(
+        default=False,
+        validator=instance_of((RGBA, RGB, str))
+    )
+    fontColor = attr.ib(
+        default=False,
+        validator=instance_of((RGBA, RGB, str))
+    )
+
+    def to_json_data(self):
+        return self.panel_json({
+            'backgroundBlink': self.backgroundBlink,    # false
+            'backgroundColor': self.backgroundColor,    # "#000"
+            'bold': self.bold,    # false
+            'decimals': self.decimals,    # 2
+            'fontColor': self.fontColor,    # "#FFF"
+            'link': self.link,    # ""
+            'mappingIds': self.mappingIds,    # []
+            'name': self.name,    # "Name"
+            "position": {*self.position},
+            'query': self.query,
+            'valueBlink': self.valueBlink,    # false
+            "visible": self.visible,    # true
+        })
+
+
+@attr.s
+class ImageItMapping:
+    pass
+
+
+@attr.s
+class ImageIt(Panel):
+    """Generates a Text panel."""
+
+    forceImageRefresh = attr.ib(default=True, validator=instance_of(bool))
+    lockSensors = attr.ib(default=False, validator=instance_of(bool))
+
+    imageUrl = attr.ib(default="", validator=instance_of(str))
+
+    sensorsTextSize = attr.ib(default=10, validator=instance_of(int))
+
+    mappings = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=instance_of(ImageItMapping),
+            iterable_validator=instance_of(list),
+        ),
+    )
+    sensors = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=instance_of(ImageItSensorQuery),
+            iterable_validator=instance_of(list),
+        ),
+    )
+
+    def to_json_data(self):
+        return self.panel_json({
+            'type': IMAGEIT_TYPE,
+            # 'transformations': self.transformations,
+            'options': {
+                'forceImageRefresh': self.forceImageRefresh,
+                'imageUrl': self.imageUrl,
+                'lockSensors': self.lockSensors,
+                'sensorsTextSize': self.sensorsTextSize,
+                'sensors': self.sensors,
+                'mappings': self.mappings,  # []
+            }
+        })
 
 
 @attr.s

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1871,7 +1871,7 @@ class ImageIt(Panel):
     sensors = attr.ib(
         default=[],
         validator=attr.validators.deep_iterable(
-            member_validator=instance_of(ImageItSensorQuery),
+            member_validator=instance_of(ImageItSensor),
             iterable_validator=instance_of(list),
         ),
     )

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1795,12 +1795,18 @@ class ImageItSensor:
     decimals = attr.ib(default=2, validator=instance_of(int))
 
     name = attr.ib(default="", validator=instance_of(str))
-    imageUrl = attr.ib(default="", validator=instance_of(str))
     link = attr.ib(default="", validator=instance_of(str))
+    unit = attr.ib(default="", validator=instance_of(str))
 
-    mappingIds = attr.ib(default=[], validator=instance_of(list))
+    mappingIds = attr.ib(
+        default=[],
+        validator=attr.validators.deep_iterable(
+            member_validator=instance_of(str),
+            iterable_validator=instance_of(list),
+        ),
+    )
 
-    position = attr.ib(default=Point2D(), validator=instance_of(Point2D))
+    position = attr.ib(default=Position(0, 0), validator=instance_of(Position))
 
     query = attr.ib(
         default=ImageItSensorQuery(id='', alias=''),
@@ -1942,7 +1948,7 @@ class ImageIt(Panel):
                 'lockSensors': self.lockSensors,
                 'sensorsTextSize': self.sensorsTextSize,
                 'sensors': self.sensors,
-                'mappings': self.mappings,  # []
+                'mappings': self.mappings,
             }
         })
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1746,30 +1746,6 @@ class ImageItSensorQuery:
 
 
 @attr.s
-class ImageItMapping:
-    """
-    ImageIt mapping
-    """
-
-    pass
-    # {
-    #     "compareTo": "123",
-    #     "description": "desc",
-    #     "id": "mapping-m286o",
-    #     "operator": "equal",
-    #     "values": {
-    #         "backgroundBlink": true,
-    #         "backgroundColor": "red",
-    #         "bold": true,
-    #         "fontColor": "yellow",
-    #         "overrideValue": "over_val",
-    #         "valueBlink": true,
-    #         "visible": true
-    #     }
-    # },
-
-
-@attr.s
 class ImageItSensor:
     """
     ImageIt sensor.

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -295,7 +295,7 @@ VTYPE_DELTA = 'delta'
 VTYPE_RANGE = 'range'
 VTYPE_DEFAULT = VTYPE_AVG
 
-Point2D = namedtuple('Point2D', 'x,y')
+Point2D = namedtuple('Point2D', 'x,y', defaults=(0, 0))
 
 
 @attr.s
@@ -1764,7 +1764,7 @@ class ImageItSensor:
 
     mappingIds = attr.ib(default=[], validator=instance_of(list))
 
-    position = attr.ib(default=Point2D(0, 0), validator=instance_of(Point2D))
+    position = attr.ib(default=Point2D(), validator=instance_of(Point2D))
 
     query = attr.ib(
         default=ImageItSensorQuery(id='', alias=''),

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1746,6 +1746,30 @@ class ImageItSensorQuery:
 
 
 @attr.s
+class ImageItMapping:
+    """
+    ImageIt mapping
+    """
+
+    pass
+    # {
+    #     "compareTo": "123",
+    #     "description": "desc",
+    #     "id": "mapping-m286o",
+    #     "operator": "equal",
+    #     "values": {
+    #         "backgroundBlink": true,
+    #         "backgroundColor": "red",
+    #         "bold": true,
+    #         "fontColor": "yellow",
+    #         "overrideValue": "over_val",
+    #         "valueBlink": true,
+    #         "visible": true
+    #     }
+    # },
+
+
+@attr.s
 class ImageItSensor:
     """
     ImageIt sensor.

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -579,14 +579,15 @@ def _balance_panels(panels):
 @attr.s
 class Position:
     """
-    Position with x, y position.
+    Position with x, y position. When used in ImageIt, the values are
+    interpreted as 0-100% of the image width (and height resp.).
 
     :param x: x cordinate
     :param y: y cordinate
     """
 
-    x = attr.ib(validator=instance_of(int))
-    y = attr.ib(validator=instance_of(int))
+    x = attr.ib(validator=instance_of((int, float)))
+    y = attr.ib(validator=instance_of((int, float)))
 
     def to_json_data(self):
         return {
@@ -596,7 +597,7 @@ class Position:
 
 
 @attr.s
-class GridPos(Position):
+class GridPos:
     """GridPos describes the panel size and position in grid coordinates.
 
     :param h: height of the panel, grid height units each represents
@@ -607,8 +608,10 @@ class GridPos(Position):
     :param y: y cordinate of the panel, in same unit as h
     """
 
-    h = attr.ib(validator=instance_of(int))
-    w = attr.ib(validator=instance_of(int))
+    h = attr.ib(validator=instance_of((int, float)))
+    w = attr.ib(validator=instance_of((int, float)))
+    x = attr.ib(validator=instance_of((int, float)))
+    y = attr.ib(validator=instance_of((int, float)))
 
     def to_json_data(self):
         return {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -579,9 +579,7 @@ def _balance_panels(panels):
 @attr.s
 class Position:
     """
-    Position with x, y position. When used in ImageIt, the values are
-    interpreted as 0-100% of the image width resp. height. Sensors then will
-    be attached with their upper left corner to this position.
+    Generic version of Position with x, y coordinates.
 
     :param x: x cordinate
     :param y: y cordinate
@@ -1753,12 +1751,12 @@ class ImageItSensorQuery:
     """
     ImageIt sensor query
 
-    :param alias:
-    :param id:
+    :param id: Query ID to use (aka refId)
+    :param alias: dito
     """
 
-    alias = attr.ib(default='', validator=instance_of(str))
     id = attr.ib(default='', validator=instance_of(str))
+    alias = attr.ib(default='', validator=instance_of(str))
 
     def to_json_data(self):
         return {
@@ -1772,19 +1770,22 @@ class ImageItSensor:
     """
     ImageIt sensor.
 
-    :param backgroundBlink:
-    :param bold:
-    :param valueBlink:
-    :param visible:
-    :param decimals:
-    :param name:
-    :param link:
-    :param unit:
-    :param mappingIds:
-    :param position:
-    :param query:
-    :param backgroundColor:
-    :param fontColor:
+    :param backgroundBlink: dito
+    :param bold: dito
+    :param valueBlink: dito
+    :param visible: dito
+    :param decimals: dito
+    :param name: name to be displayed
+    :param link: link to open upon clicking on the sensor tile
+    :param unit: unit of this sensor
+    :param mappingIds: ID of maps to apply for this sensor (see
+        ImageItMapping class for details)
+    :param position: where to place (upper left corner of the) sensor onto the
+        image (see Position class for details)
+    :param query: which query to use for value retrieval (see Position class
+        for details)
+    :param backgroundColor: dito
+    :param fontColor: dito
     """
 
     backgroundBlink = attr.ib(default=False, validator=instance_of(bool))
@@ -1843,19 +1844,21 @@ class ImageItSensor:
 @attr.s
 class ImageItMapping:
     """
-    ImageItMapping
+    ImageItMapping changes the appearance/behavior of the sensor referencing
+    the given ID.
 
-    :param backgroundBlink:
-    :param bold:
-    :param valueBlink:
-    :param visible:
-    :param compareTo:
-    :param description:
-    :param overrideValue:
-    :param operator:
-    :param id:
-    :param backgroundColor:
-    :param fontColor:
+    :param backgroundBlink: dito
+    :param bold: dito
+    :param valueBlink: dito
+    :param visible: dito
+    :param compareTo: value to compare to
+    :param description: dito
+    :param overrideValue: ?
+    :param operator: comparison operator to use: 'equal', 'notEqual',
+        'smallerThan', 'greaterThan'
+    :param id: ID of this mapping, can be used by ImageItSensor.
+    :param backgroundColor: dito
+    :param fontColor: dito
     """
 
     backgroundBlink = attr.ib(default=False, validator=instance_of(bool))
@@ -1910,12 +1913,14 @@ class ImageIt(Panel):
     Generates a ImageIt panel. See:
     https://grafana.com/grafana/plugins/pierosavi-imageit-panel/ for details.
 
-    :param forceImageRefresh:
-    :param lockSensors:
-    :param imageUrl:
-    :param sensorsTextSize:
-    :param mappings:
-    :param sensors:
+    :param forceImageRefresh: whether to force refresh on dashboard should be
+        used carefully (https://github.com/pierosavi/pierosavi-imageit-panel#whats-up-with-the-force-image-refresh-warning)
+    :param lockSensors: lock the sensor in place (can not be moved manually
+        anymore)
+    :param imageUrl: dito (note: https://github.com/pierosavi/pierosavi-imageit-panel#can-i-host-my-images-inside-my-grafana-instance)
+    :param sensorsTextSize: dito
+    :param mappings: mapping for this panel (list of ImageItMapping)
+    :param sensors: sensors for this panel (list of ImageItSensor)
     """
 
     forceImageRefresh = attr.ib(default=False, validator=instance_of(bool))

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -580,7 +580,8 @@ def _balance_panels(panels):
 class Position:
     """
     Position with x, y position. When used in ImageIt, the values are
-    interpreted as 0-100% of the image width (and height resp.).
+    interpreted as 0-100% of the image width resp. height. Sensors then will
+    be attached with their upper left corner to this position.
 
     :param x: x cordinate
     :param y: y cordinate

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -16,7 +16,6 @@ from numbers import Number
 
 import attr
 from attr.validators import in_, instance_of
-from collections import namedtuple
 
 
 @attr.s
@@ -295,8 +294,6 @@ VTYPE_FIRST = 'first'
 VTYPE_DELTA = 'delta'
 VTYPE_RANGE = 'range'
 VTYPE_DEFAULT = VTYPE_AVG
-
-Point2D = namedtuple('Point2D', 'x,y', defaults=(0, 0))
 
 
 @attr.s
@@ -580,7 +577,26 @@ def _balance_panels(panels):
 
 
 @attr.s
-class GridPos(object):
+class Position:
+    """
+    Position with x, y position.
+
+    :param x: x cordinate
+    :param y: y cordinate
+    """
+
+    x = attr.ib(validator=instance_of(int))
+    y = attr.ib(validator=instance_of(int))
+
+    def to_json_data(self):
+        return {
+            'x': self.x,
+            'y': self.y,
+        }
+
+
+@attr.s
+class GridPos(Position):
     """GridPos describes the panel size and position in grid coordinates.
 
     :param h: height of the panel, grid height units each represents
@@ -591,17 +607,15 @@ class GridPos(object):
     :param y: y cordinate of the panel, in same unit as h
     """
 
-    h = attr.ib()
-    w = attr.ib()
-    x = attr.ib()
-    y = attr.ib()
+    h = attr.ib(validator=instance_of(int))
+    w = attr.ib(validator=instance_of(int))
 
     def to_json_data(self):
         return {
             'h': self.h,
             'w': self.w,
             'x': self.x,
-            'y': self.y
+            'y': self.y,
         }
 
 

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -181,18 +181,74 @@ def test_DiscreteColorMappingItem():
     assert json_data['color'] == 'bar'
 
 
+def test_Discrete_exceptions():
+    with pytest.raises(ValueError):
+        G.Discrete(legendSortBy='foo')
+
+    with pytest.raises(TypeError):
+        G.Discrete(rangeMaps=[123, 456])
+
+    with pytest.raises(TypeError):
+        G.Discrete(valueMaps=['foo', 'bar'])
+
+    with pytest.raises(TypeError):
+        G.Discrete(lineColor=123)
+
+    with pytest.raises(TypeError):
+        G.Discrete(highlightOnMouseover=123)
+
+
 def test_Discrete():
     colorMap = [
         G.DiscreteColorMappingItem('bar', color='baz'),
         G.DiscreteColorMappingItem('foz', color='faz')
     ]
 
-    t = G.Discrete('foo', colorMapsItems=colorMap)
+    t = G.Discrete(
+        title='foo',
+        colorMaps=colorMap,
+        lineColor='#aabbcc',
+        metricNameColor=G.RGBA(1, 2, 3, .5),
+        decimals=123,
+        highlightOnMouseover=False,
+        showDistinctCount=True,
+        showLegendCounts=False,
+    )
 
     json_data = t.to_json_data()
     assert json_data['colorMaps'] == colorMap
-    assert json_data['title'] == ''
+    assert json_data['title'] == 'foo'
     assert json_data['type'] == G.DISCRETE_TYPE
+    assert json_data['rangeMaps'] == []
+    assert json_data['valueMaps'] == []
+
+    assert json_data['backgroundColor'] == G.RGBA(128, 128, 128, 0.1)
+    assert json_data['lineColor'] == '#aabbcc'
+    assert json_data['metricNameColor'] == G.RGBA(1, 2, 3, .5)
+    assert json_data['timeTextColor'] == "#d8d9da"
+    assert json_data['valueTextColor'] == "#000000"
+
+    assert json_data['decimals'] == 123
+    assert json_data['legendPercentDecimals'] == 0
+    assert json_data['rowHeight'] == 50
+    assert json_data['textSize'] == 24
+    assert json_data['textSizeTime'] == 12
+
+    assert json_data['highlightOnMouseover'] is False
+    assert json_data['showLegend'] is True
+    assert json_data['showLegendPercent'] is True
+    assert json_data['showLegendNames'] is True
+    assert json_data['showLegendValues'] is True
+    assert json_data['showTimeAxis'] is True
+    assert json_data['use12HourClock'] is False
+    assert json_data['writeMetricNames'] is False
+    assert json_data['writeLastValue'] is True
+    assert json_data['writeAllValues'] is False
+
+    assert json_data['showDistinctCount'] is True
+    assert json_data['showLegendCounts'] is False
+    assert json_data['showLegendTime'] is None
+    assert json_data['showTransitionCount'] is None
 
 
 def test_StatValueMappings_exception_checks():

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -236,6 +236,12 @@ def test_ImageItSensor_exception_checks():
     with pytest.raises(TypeError):
         G.ImageItSensor(query=123)
 
+    with pytest.raises(TypeError):
+        G.ImageItSensor(mappingIds=123)
+
+    with pytest.raises(TypeError):
+        G.ImageItSensor(mappingIds=[123, 456])
+
 
 def test_ImageItSensor():
     t = G.ImageItSensor()
@@ -263,7 +269,7 @@ def test_ImageItSensor():
         backgroundBlink=True,
         name="foo",
         decimals=123,
-        mappingIds=[123, 456],
+        mappingIds=['abc', 'def'],
         query=G.ImageItSensorQuery(alias='foo', id='bar'),
         position=G.Position(789, 321),
     )
@@ -273,7 +279,7 @@ def test_ImageItSensor():
     assert json_data['backgroundBlink'] is True
     assert json_data['name'] == 'foo'
     assert json_data['decimals'] == 123
-    assert json_data['mappingIds'] == [123, 456]
+    assert json_data['mappingIds'] == ['abc', 'def']
     assert json_data['query'] == G.ImageItSensorQuery(alias='foo', id='bar')
     assert json_data['position'] == G.Position(789, 321)
 

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -159,6 +159,33 @@ def test_stat_no_repeat():
     assert t.to_json_data()['maxPerRow'] is None
 
 
+def test_Text_exception_checks():
+    with pytest.raises(TypeError):
+        G.Text(content=123)
+
+    with pytest.raises(TypeError):
+        G.Text(error=123)
+
+    with pytest.raises(ValueError):
+        G.Text(mode=123)
+
+
+def test_Text():
+    t = G.Text()
+
+    json_data = t.to_json_data()
+    assert json_data['error'] is False
+    assert json_data['options']['content'] == ""
+    assert json_data['options']['mode'] == G.TEXT_MODE_MARKDOWN
+
+    t = G.Text(content='foo', error=True, mode=G.TEXT_MODE_HTML)
+
+    json_data = t.to_json_data()
+    assert json_data['error'] is True
+    assert json_data['options']['content'] == "foo"
+    assert json_data['options']['mode'] == G.TEXT_MODE_HTML
+
+
 def test_DiscreteColorMappingItem_exception_checks():
     with pytest.raises(TypeError):
         G.DiscreteColorMappingItem(123)

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -174,7 +174,7 @@ def test_ImageItMapping():
     assert json_data['compareTo'] == ''
     assert json_data['description'] == ''
     assert json_data['id'].startswith('mapping_')
-    assert json_data['operator'] == '='
+    assert json_data['operator'] == 'equal'
 
     assert json_data['values']['fontColor'] == '#FFF'
     assert json_data['values']['backgroundColor'] == '#000'
@@ -188,7 +188,7 @@ def test_ImageItMapping():
     t = G.ImageItMapping(
         id="foo",
         compareTo="123",
-        operator="<",
+        operator="smallerThan",
         description="desc",
         fontColor="#ABC",
         overrideValue="override",
@@ -199,7 +199,7 @@ def test_ImageItMapping():
     assert json_data['compareTo'] == '123'
     assert json_data['description'] == 'desc'
     assert json_data['id'] == "foo"
-    assert json_data['operator'] == '<'
+    assert json_data['operator'] == 'smallerThan'
 
     assert json_data['values']['fontColor'] == '#ABC'
     assert json_data['values']['overrideValue'] == 'override'
@@ -320,7 +320,7 @@ def test_ImageIt():
     mappings = [
         G.ImageItMapping(),
         G.ImageItMapping(
-            operator='>',
+            operator='greaterThan',
             compareTo="456",
             fontColor='#AAAAAA'
         )

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -306,7 +306,7 @@ def test_ImageIt():
     json_data = t.to_json_data()
 
     assert json_data['type'] == G.IMAGEIT_TYPE
-    assert json_data['options']['forceImageRefresh'] is True
+    assert json_data['options']['forceImageRefresh'] is False
     assert json_data['options']['lockSensors'] is False
     assert json_data['options']['imageUrl'] == ''
     assert json_data['options']['sensorsTextSize'] == 10

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -278,6 +278,63 @@ def test_ImageItSensor():
     assert json_data['position'] == G.Point2D(789, 321)
 
 
+def test_ImageIt_exception_checks():
+    with pytest.raises(TypeError):
+        G.ImageIt(mappings=123)
+
+    with pytest.raises(TypeError):
+        G.ImageIt(mappings=[123, 456])
+
+    with pytest.raises(TypeError):
+        G.ImageIt(sensors=123)
+
+    with pytest.raises(TypeError):
+        G.ImageIt(sensors=[123, 456])
+
+
+def test_ImageIt():
+    t = G.ImageIt()
+    json_data = t.to_json_data()
+
+    assert json_data['type'] == G.IMAGEIT_TYPE
+    assert json_data['options']['forceImageRefresh'] is True
+    assert json_data['options']['lockSensors'] is False
+    assert json_data['options']['imageUrl'] == ''
+    assert json_data['options']['sensorsTextSize'] == 10
+    assert json_data['options']['sensors'] == []
+    assert json_data['options']['mappings'] == []
+
+    sensors = [
+        G.ImageItSensor(),
+        G.ImageItSensor(query=G.ImageItSensorQuery(alias='foo')),
+    ]
+    mappings = [
+        G.ImageItMapping(),
+        G.ImageItMapping(
+            operator='>',
+            compareTo="456",
+            fontColor='#AAAAAA'
+        )
+    ]
+
+    t = G.ImageIt(
+        forceImageRefresh=False,
+        imageUrl="foo://bar.com/img",
+        sensorsTextSize=123,
+        sensors=sensors,
+        mappings=mappings,
+    )
+
+    json_data = t.to_json_data()
+
+    assert json_data['type'] == G.IMAGEIT_TYPE
+    assert json_data['options']['forceImageRefresh'] is False
+    assert json_data['options']['imageUrl'] == 'foo://bar.com/img'
+    assert json_data['options']['sensorsTextSize'] == 123
+    assert json_data['options']['sensors'] == sensors
+    assert json_data['options']['mappings'] == mappings
+
+
 def test_Text_exception_checks():
     with pytest.raises(TypeError):
         G.Text(content=123)

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -257,6 +257,7 @@ def test_ImageItSensor():
 
     assert json_data['name'] == ''
     assert json_data['link'] == ''
+    assert json_data['unit'] == ''
 
     assert json_data['decimals'] == 2
 
@@ -268,6 +269,7 @@ def test_ImageItSensor():
         backgroundColor='#ABC',
         backgroundBlink=True,
         name="foo",
+        unit="unit",
         decimals=123,
         mappingIds=['abc', 'def'],
         query=G.ImageItSensorQuery(alias='foo', id='bar'),
@@ -278,6 +280,7 @@ def test_ImageItSensor():
     assert json_data['backgroundColor'] == '#ABC'
     assert json_data['backgroundBlink'] is True
     assert json_data['name'] == 'foo'
+    assert json_data['unit'] == 'unit'
     assert json_data['decimals'] == 123
     assert json_data['mappingIds'] == ['abc', 'def']
     assert json_data['query'] == G.ImageItSensorQuery(alias='foo', id='bar')

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -181,6 +181,55 @@ def test_ImageItSensorQuery():
     assert json_data['id'] == 'bar'
 
 
+def test_ImageItSensor_exception_checks():
+    with pytest.raises(TypeError):
+        G.ImageItSensor(position=123)
+
+    with pytest.raises(TypeError):
+        G.ImageItSensor(query=123)
+
+
+def test_ImageItSensor():
+    t = G.ImageItSensor()
+
+    json_data = t.to_json_data()
+    assert json_data['backgroundColor'] == '#000'
+    assert json_data['fontColor'] == '#FFF'
+
+    assert json_data['backgroundBlink'] is False
+    assert json_data['bold'] is False
+    assert json_data['valueBlink'] is False
+    assert json_data['visible'] is True
+
+    assert json_data['name'] == ''
+    assert json_data['link'] == ''
+
+    assert json_data['decimals'] == 2
+
+    assert json_data['mappingIds'] == []
+    assert json_data['query'] == G.ImageItSensorQuery()
+    assert json_data['position'] == G.Point2D()
+
+    t = G.ImageItSensor(
+        backgroundColor='#ABC',
+        backgroundBlink=True,
+        name="foo",
+        decimals=123,
+        mappingIds=[123, 456],
+        query=G.ImageItSensorQuery(alias='foo', id='bar'),
+        position=G.Point2D(789, 321),
+    )
+
+    json_data = t.to_json_data()
+    assert json_data['backgroundColor'] == '#ABC'
+    assert json_data['backgroundBlink'] is True
+    assert json_data['name'] == 'foo'
+    assert json_data['decimals'] == 123
+    assert json_data['mappingIds'] == [123, 456]
+    assert json_data['query'] == G.ImageItSensorQuery(alias='foo', id='bar')
+    assert json_data['position'] == G.Point2D(789, 321)
+
+
 def test_Text_exception_checks():
     with pytest.raises(TypeError):
         G.Text(content=123)

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -159,6 +159,28 @@ def test_stat_no_repeat():
     assert t.to_json_data()['maxPerRow'] is None
 
 
+def test_ImageItSensorQuery_exception_checks():
+    with pytest.raises(TypeError):
+        G.ImageItSensorQuery(alias=123)
+
+    with pytest.raises(TypeError):
+        G.ImageItSensorQuery(id=123)
+
+
+def test_ImageItSensorQuery():
+    t = G.ImageItSensorQuery()
+
+    json_data = t.to_json_data()
+    assert json_data['alias'] == ''
+    assert json_data['id'] == ''
+
+    t = G.ImageItSensorQuery(alias='foo', id='bar')
+
+    json_data = t.to_json_data()
+    assert json_data['alias'] == 'foo'
+    assert json_data['id'] == 'bar'
+
+
 def test_Text_exception_checks():
     with pytest.raises(TypeError):
         G.Text(content=123)

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -256,7 +256,7 @@ def test_ImageItSensor():
 
     assert json_data['mappingIds'] == []
     assert json_data['query'] == G.ImageItSensorQuery()
-    assert json_data['position'] == G.Point2D()
+    assert json_data['position'] == G.Position(0, 0)
 
     t = G.ImageItSensor(
         backgroundColor='#ABC',
@@ -265,7 +265,7 @@ def test_ImageItSensor():
         decimals=123,
         mappingIds=[123, 456],
         query=G.ImageItSensorQuery(alias='foo', id='bar'),
-        position=G.Point2D(789, 321),
+        position=G.Position(789, 321),
     )
 
     json_data = t.to_json_data()
@@ -275,7 +275,7 @@ def test_ImageItSensor():
     assert json_data['decimals'] == 123
     assert json_data['mappingIds'] == [123, 456]
     assert json_data['query'] == G.ImageItSensorQuery(alias='foo', id='bar')
-    assert json_data['position'] == G.Point2D(789, 321)
+    assert json_data['position'] == G.Position(789, 321)
 
 
 def test_ImageIt_exception_checks():
@@ -360,6 +360,42 @@ def test_Text():
     assert json_data['error'] is True
     assert json_data['options']['content'] == "foo"
     assert json_data['options']['mode'] == G.TEXT_MODE_HTML
+
+
+def test_Position_exception_checks():
+    with pytest.raises(TypeError):
+        G.Position(x='foo', y=123.4)
+    with pytest.raises(TypeError):
+        G.Position(x=123, y='bar')
+
+
+def test_Position():
+    t = G.Position(x=123.4, y=456)
+
+    json_data = t.to_json_data()
+    assert json_data['x'] == 123.4
+    assert json_data['y'] == 456
+
+
+def test_GridPos_exception_checks():
+    with pytest.raises(TypeError):
+        G.GridPos(h='foo', w=2, x=3, y=4)
+    with pytest.raises(TypeError):
+        G.GridPos(h=1.1, w='bar', x=3, y=4)
+    with pytest.raises(TypeError):
+        G.GridPos(h=1, w=2.2, x='foz', y=4)
+    with pytest.raises(TypeError):
+        G.GridPos(h=1, w=2, x=3.3, y='baz')
+
+
+def test_GridPos():
+    t = G.GridPos(h=321, w=654.3, x=123, y=456.7)
+
+    json_data = t.to_json_data()
+    assert json_data['h'] == 321
+    assert json_data['w'] == 654.3
+    assert json_data['x'] == 123
+    assert json_data['y'] == 456.7
 
 
 def test_DiscreteColorMappingItem_exception_checks():

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -159,6 +159,54 @@ def test_stat_no_repeat():
     assert t.to_json_data()['maxPerRow'] is None
 
 
+def test_ImageItMapping_exception_checks():
+    with pytest.raises(ValueError):
+        G.ImageItMapping(operator='foo')
+
+    with pytest.raises(TypeError):
+        G.ImageItMapping(id=123)
+
+
+def test_ImageItMapping():
+    t = G.ImageItMapping()
+
+    json_data = t.to_json_data()
+    assert json_data['compareTo'] == ''
+    assert json_data['description'] == ''
+    assert json_data['id'].startswith('mapping_')
+    assert json_data['operator'] == '='
+
+    assert json_data['values']['fontColor'] == '#FFF'
+    assert json_data['values']['backgroundColor'] == '#000'
+    assert json_data['values']['overrideValue'] == ''
+
+    assert json_data['values']['backgroundBlink'] is False
+    assert json_data['values']['bold'] is False
+    assert json_data['values']['valueBlink'] is False
+    assert json_data['values']['visible'] is True
+
+    t = G.ImageItMapping(
+        id="foo",
+        compareTo="123",
+        operator="<",
+        description="desc",
+        fontColor="#ABC",
+        overrideValue="override",
+        backgroundBlink=True,
+    )
+
+    json_data = t.to_json_data()
+    assert json_data['compareTo'] == '123'
+    assert json_data['description'] == 'desc'
+    assert json_data['id'] == "foo"
+    assert json_data['operator'] == '<'
+
+    assert json_data['values']['fontColor'] == '#ABC'
+    assert json_data['values']['overrideValue'] == 'override'
+
+    assert json_data['values']['backgroundBlink'] is True
+
+
 def test_ImageItSensorQuery_exception_checks():
     with pytest.raises(TypeError):
         G.ImageItSensorQuery(alias=123)


### PR DESCRIPTION
## What does this do?
- Adds support for https://grafana.com/grafana/plugins/pierosavi-imageit-panel/.
- Fixes Text panel (for v8?)
- Add tests for GridPos and restrict input to `int` and `float`

## Why is it a good idea?
Makes grafanlib more feature rich.
