### PR TITLE
Move Matt to maintainer alumni

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,11 +7,11 @@ https://weave-community.slack.com/ in #grafanalib (https://weave-community.slack
 
 Daniel Holbach, Weaveworks <daniel@weave.works> (github: @dholbach, slack: dholbach)
 James Gibson, BBC <james.gibson@bbc.co.uk> (github: @JamesGibo, slack: James G)
-Matt Richter, Validity HQ <matthewmrichter@gmail.com> (github: @matthewmrichter, slack: Matt Richter)
 
 Retired maintainers:
 
 - Bryan Boreham
 - Jonathan Lange
+- Matt Richter
 
 Thank you for your involvement, and let us not say "farewell" ...


### PR DESCRIPTION
	Matt Richter stepped down as maintainer a couple of months
	back. Here I'm catching up the MAINTAINERS file to reflect
	this.

	Thanks for all your help and we hope to see you still
	around! All the best!