### PR TITLE
Add MinMetricAgg and PercentilesMetricAgg to elasticsearch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ x.x.x (TBD)
 * Added support for colors in stat mapping panel with StatValueMappings & StatRangeMappings
 * Added missing auto interval properties in Template
 * Added support for time series panel added in Grafana v8
+* Added MinMetricAgg and PercentilesMetricAgg to Elasticsearch
 
 Changes
 -------

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -431,3 +431,70 @@ class ElasticsearchAlertCondition(AlertCondition):
     """
 
     target = attr.ib(validator=instance_of(ElasticsearchTarget))
+
+
+@attr.s
+class MinMetricAgg(object):
+    """An aggregator that provides the min. value among the values.
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
+    :param field: name of elasticsearch field to provide the maximum for
+    :param hide: show/hide the metric in the final panel display
+    :param id: id of the metric
+    :param inline: script to apply to the data, using '_value'
+    """
+
+    field = attr.ib(default="", validator=instance_of(str))
+    id = attr.ib(default=0, validator=instance_of(int))
+    hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
+
+    def to_json_data(self):
+        self.settings = {}
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
+        return {
+            'id': str(self.id),
+            'hide': self.hide,
+            'type': 'min',
+            'field': self.field,
+            'inlineScript': self.inline,
+            'settings': self.settings,
+        }
+
+
+@attr.s
+class PercentilesMetricAgg(object):
+    """A multi-value metrics aggregation that calculates one or more percentiles over numeric values extracted from the aggregated documents
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
+    :param field: name of elasticsearch field to provide the maximum for
+    :param hide: show/hide the metric in the final panel display
+    :param id: id of the metric
+    :param inline: script to apply to the data, using '_value'
+    :param percents: list of percentiles, like [95,99]
+    """
+
+    field = attr.ib(default="", validator=instance_of(str))
+    id = attr.ib(default=0, validator=instance_of(int))
+    hide = attr.ib(default=False, validator=instance_of(bool))
+    inline = attr.ib(default="", validator=instance_of(str))
+    percents = attr.ib(default=attr.Factory(list))
+    settings = attr.ib(default={})
+
+    def to_json_data(self):
+        self.settings = {}
+
+        self.settings['percents'] = self.percents
+
+        if self.inline:
+            self.settings['script'] = {'inline': self.inline}
+
+        return {
+            'id': str(self.id),
+            'hide': self.hide,
+            'type': 'percentiles',
+            'field': self.field,
+            'inlineScript': self.inline,
+            'settings': self.settings,
+        }


### PR DESCRIPTION
## What does this do?
I was playing around with this package and I noticed that there is no support for min and percentiles aggregations. While porting my current code to this lib, I created both classes and decided to upstream to library, so everyone can enjoy

## Why is it a good idea?
This adds more resources and power for users of the library that uses ElasticSearch as a datasource

## Questions
I noticed that ES classes has no tests. I don't know the reason, but I kept as is and did not add any. I can add, if needed
