### PR TITLE
Add Cloudwatch Logs Insights Target

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ x.x.x (TBD)
 ==================
 
 * Added missing attributes to the Logs panel
+* Added Cloudwatch Logs Insights Target
 * ...
 
 Changes

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -58,3 +58,47 @@ class CloudwatchMetricsTarget(object):
             "statistics": self.statistics,
             "hide": self.hide,
         }
+
+
+@attr.s
+class CloudwatchLogsInsightsTarget(object):
+    """
+    Generates Cloudwatch Logs Insights target JSON structure.
+
+    Grafana docs on using Cloudwatch:
+    https://grafana.com/docs/grafana/latest/datasources/cloudwatch/
+
+    AWS docs on Cloudwatch Logs Insights:
+    https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html
+
+    :param expression: Cloudwatch Logs Insights expressions
+    :param id: unique id
+    :param logGroupNames: List of Cloudwatch log groups to query
+    :param namespace: Cloudwatch namespace
+    :param refId: target reference id
+    :param region: Cloudwatch region
+    :param statsGroups: Cloudwatch statsGroups
+    :param hide: controls if given metric is displayed on visualization
+    """
+    expression = attr.ib(default="")
+    id = attr.ib(default="")
+    logGroupNames = attr.ib(default=[], validator=instance_of(list))
+    namespace = attr.ib(default="")
+    refId = attr.ib(default="")
+    region = attr.ib(default="default")
+    statsGroups = attr.ib(default=[], validator=instance_of(list))
+    hide = attr.ib(default=False, validator=instance_of(bool))
+
+    def to_json_data(self):
+
+        return {
+            "expression": self.expression,
+            "id": self.id,
+            "logGroupNames": self.logGroupNames,
+            "namespace": self.namespace,
+            "queryMode": "Logs",
+            "refId": self.refId,
+            "region": self.region,
+            "statsGroups": self.statsGroups,
+            "hide": self.hide,
+        }

--- a/grafanalib/tests/test_cloudwatch.py
+++ b/grafanalib/tests/test_cloudwatch.py
@@ -23,3 +23,44 @@ def test_serialization_cloudwatch_metrics_target():
     stream = StringIO()
     _gen.write_dashboard(graph, stream)
     assert stream.getvalue() != ''
+
+
+def test_serialization_cloudwatch_logs_insights_target():
+    """Serializing a graph doesn't explode."""
+    graph = G.Logs(
+        title="Lambda Duration",
+        dataSource="Cloudwatch data source",
+        targets=[
+            C.CloudwatchLogsInsightsTarget(),
+        ],
+        id=1,
+        wrapLogMessages=True
+    )
+    stream = StringIO()
+    _gen.write_dashboard(graph, stream)
+    assert stream.getvalue() != ''
+
+
+def test_cloudwatch_logs_insights_target():
+    """Test Cloudwatch Logs Insights target"""
+    cloudwatch_logs_insights_expression = "fields @timestamp, @xrayTraceId, @message | filter @message like /^(?!.*(START|END|REPORT|LOGS|EXTENSION)).*$/ | sort @timestamp desc"
+    ref_id = "A"
+    log_group_names = ["/aws/lambda/foo", "/aws/lambda/bar"]
+
+    target = C.CloudwatchLogsInsightsTarget(
+        expression=cloudwatch_logs_insights_expression,
+        logGroupNames=log_group_names,
+        refId=ref_id
+    )
+
+    data = target.to_json_data()
+
+    assert data["expression"] == cloudwatch_logs_insights_expression
+    assert data["id"] == ""
+    assert data["logGroupNames"] == log_group_names
+    assert data["namespace"] == ""
+    assert data["queryMode"] == "Logs"
+    assert data["refId"] == ref_id
+    assert data["region"] == "default"
+    assert data["statsGroups"] == []
+    assert data["hide"] is False


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Introduces the [Cloudwatch Logs Insights Target](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#using-the-logs-query-editor)

## Why is it a good idea?
We can visualise both Cloudwatch metrics and logs within the same dashboard

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
