### PR TITLE
Revert to wrapLogMessages

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3110,7 +3110,7 @@ class Logs(Panel):
     showLabels = attr.ib(default=False, validator=instance_of(bool))
     showCommonLabels = attr.ib(default=False, validator=instance_of(bool))
     showTime = attr.ib(default=False, validator=instance_of(bool))
-    wrapLogMessage = attr.ib(default=False, validator=instance_of(bool))
+    wrapLogMessages = attr.ib(default=False, validator=instance_of(bool))
     sortOrder = attr.ib(default='Descending', validator=instance_of(str))
     dedupStrategy = attr.ib(default='none', validator=instance_of(str))
     enableLogDetails = attr.ib(default=False, validator=instance_of(bool))
@@ -3129,7 +3129,7 @@ class Logs(Panel):
                     'showLabels': self.showLabels,
                     'showCommonLabels': self.showCommonLabels,
                     'showTime': self.showTime,
-                    'wrapLogMessage': self.wrapLogMessage,
+                    'wrapLogMessage': self.wrapLogMessages,
                     'sortOrder': self.sortOrder,
                     'dedupStrategy': self.dedupStrategy,
                     'enableLogDetails': self.enableLogDetails,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Reverts to `wrapLogMessages` from `wrapLogMessage` introduced in #410 

## Why is it a good idea?
To maintain backward compatibility

## Context
`wrapLogMessages` was changed to `wrapLogMessage` in the Logs panel to reflect how the dashboard is represented as JSON in Grafana. However this change is not backwards compatible.


## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
