### PR TITLE
Add missing overrides to timeseries visualization

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1505,6 +1505,7 @@ class TimeSeries(Panel):
         linear (Default), smooth, stepBefore, stepAfter
     :param lineWidth: line width, default 1
     :param mappings: To assign colors to boolean or string values, use Value mappings
+    :param overrides: To override the base characteristics of certain timeseries data
     :param pointSize: point size, default 5
     :param scaleDistributionType: axis scale linear or log
     :param scaleDistributionLog: Base of if logarithmic scale type set, default 2
@@ -1530,6 +1531,7 @@ class TimeSeries(Panel):
     lineInterpolation = attr.ib(default='linear', validator=instance_of(str))
     lineWidth = attr.ib(default=1, validator=instance_of(int))
     mappings = attr.ib(default=attr.Factory(list))
+    overrides = attr.ib(default=attr.Factory(list))
     pointSize = attr.ib(default=5, validator=instance_of(int))
     scaleDistributionType = attr.ib(default='linear', validator=instance_of(str))
     scaleDistributionLog = attr.ib(default=2, validator=instance_of(int))
@@ -1578,7 +1580,7 @@ class TimeSeries(Panel):
                         },
                         'unit': self.unit
                     },
-                    'overrides': []
+                    'overrides': self.overrides
                 },
                 'options': {
                     'legend': {

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -506,6 +506,42 @@ def test_timeseries():
     assert data['targets'] == targets
     assert data['datasource'] == data_source
     assert data['title'] == title
+    assert data['fieldConfig']['overrides'] == []
+
+
+def test_timeseries_with_overrides():
+    data_source = 'dummy data source'
+    targets = ['dummy_prom_query']
+    title = 'dummy title'
+    overrides = [
+        {
+            "matcher": {
+                "id": "byName",
+                "options": "min"
+            },
+            "properties": [
+                {
+                    "id": "custom.fillBelowTo",
+                    "value": "min"
+                },
+                {
+                    "id": "custom.lineWidth",
+                    "value": 0
+                }
+            ]
+        }
+    ]
+    timeseries = G.TimeSeries(
+        dataSource=data_source,
+        targets=targets,
+        title=title,
+        overrides=overrides,
+    )
+    data = timeseries.to_json_data()
+    assert data['targets'] == targets
+    assert data['datasource'] == data_source
+    assert data['title'] == title
+    assert data['fieldConfig']['overrides'] == overrides
 
 
 def test_news():


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
This PR adds the missing attributes to timeseries visualization

## Why is it a good idea?
This allows the grafanalib users to override series in Timeseries visualization

## Context
![Screenshot 2021-11-01 at 9 41 15 AM](https://user-images.githubusercontent.com/5619473/139645187-9309a33d-b19f-4310-a508-839d768e7c83.png)



## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
