### PR TITLE
Add SQL Target

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,16 @@ Changes
 
 * ...
 
+0.6.1 (TBD)
+==================
+
+* Added new SqlTarget to core to be able to define SQL queries as well
+
+Changes
+-------
+
+* Add SqlTarget
+
 0.6.0 (2021-10-26)
 ===================
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -426,6 +426,7 @@ class Target(object):
             'datasource': self.datasource,
         }
 
+
 @attr.s
 class SqlTarget(Target):
     """

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -426,6 +426,18 @@ class Target(object):
             'datasource': self.datasource,
         }
 
+@attr.s
+class SqlTarget(Target):
+    """
+    Metric in sql foramt
+    """
+    rawSql = attr.ib(default="")
+    def to_json_data(self):
+        super_json = super(SqlTarget, self).to_json_data()
+        super_json['rawSql'] = self.rawSql
+        super_json['rawQuery'] = True
+        return super_json
+
 
 @attr.s
 class Tooltip(object):

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -430,10 +430,16 @@ class Target(object):
 @attr.s
 class SqlTarget(Target):
     """
-    Metric in sql foramt
+    Metric target to support SQL queries
     """
     rawSql = attr.ib(default="")
+
     def to_json_data(self):
+        """Override the Target to_json_data to add additional fields.
+           rawSql: this will contain the actual SQL queries
+           rawQuery: this needs to be set to True as in case of False
+                     the rawSql would be unused
+        """
         super_json = super(SqlTarget, self).to_json_data()
         super_json['rawSql'] = self.rawSql
         super_json['rawQuery'] = True

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -432,17 +432,19 @@ class SqlTarget(Target):
     """
     Metric target to support SQL queries
     """
+
     rawSql = attr.ib(default="")
+    rawQuery = attr.ib(default=True)
 
     def to_json_data(self):
         """Override the Target to_json_data to add additional fields.
-           rawSql: this will contain the actual SQL queries
-           rawQuery: this needs to be set to True as in case of False
-                     the rawSql would be unused
+        rawSql: this will contain the actual SQL queries
+        rawQuery: this is set to True by default as in case of False
+                  the rawSql would be unused
         """
         super_json = super(SqlTarget, self).to_json_data()
-        super_json['rawSql'] = self.rawSql
-        super_json['rawQuery'] = True
+        super_json["rawSql"] = self.rawSql
+        super_json["rawQuery"] = self.rawQuery
         return super_json
 
 

--- a/grafanalib/tests/examples/example.dashboard-with-sql.py
+++ b/grafanalib/tests/examples/example.dashboard-with-sql.py
@@ -1,0 +1,34 @@
+from grafanalib.core import (
+    Dashboard,
+    Graph,
+    GridPos,
+    OPS_FORMAT,
+    RowPanel,
+    SHORT_FORMAT,
+    SqlTarget,
+    YAxes,
+    YAxis,
+)
+
+
+dashboard = Dashboard(
+    title="Random stats from SQL DB",
+    panels=[
+        RowPanel(title="New row", gridPos=GridPos(h=1, w=24, x=0, y=8)),
+        Graph(
+            title="Some SQL Queries",
+            dataSource="Your SQL Source",
+            targets=[
+                SqlTarget(
+                    rawSql='SELECT date as "time", metric FROM example WHERE $__timeFilter("time")',
+                    refId="A",
+                ),
+            ],
+            yAxes=YAxes(
+                YAxis(format=OPS_FORMAT),
+                YAxis(format=SHORT_FORMAT),
+            ),
+            gridPos=GridPos(h=8, w=24, x=0, y=9),
+        ),
+    ],
+).auto_panel_ids()

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -562,3 +562,14 @@ def test_pieChartv2():
     assert data['targets'] == targets
     assert data['datasource'] == data_source
     assert data['title'] == title
+    
+def test_sql_target():
+    t = G.Table(
+        dataSource='some data source',
+        targets=[
+            G.SqlTarget(rawSql='SELECT * FROM example'),
+        ],
+        title='table title'
+    )
+    assert t.to_json_data()['targets'][0]["rawQuery"] == True
+    assert t.to_json_data()['targets'][0]["rawSql"] == "SELECT * FROM example"

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -538,38 +538,39 @@ def test_timeseries_with_overrides():
         overrides=overrides,
     )
     data = timeseries.to_json_data()
-    assert data['targets'] == targets
-    assert data['datasource'] == data_source
-    assert data['title'] == title
-    assert data['fieldConfig']['overrides'] == overrides
+    assert data["targets"] == targets
+    assert data["datasource"] == data_source
+    assert data["title"] == title
+    assert data["fieldConfig"]["overrides"] == overrides
 
 
 def test_news():
-    title = 'dummy title'
+    title = "dummy title"
     feedUrl = "www.example.com"
     news = G.News(title=title, feedUrl=feedUrl)
     data = news.to_json_data()
-    assert data['options']['feedUrl'] == feedUrl
-    assert data['title'] == title
+    assert data["options"]["feedUrl"] == feedUrl
+    assert data["title"] == title
 
 
 def test_pieChartv2():
-    data_source = 'dummy data source'
-    targets = ['dummy_prom_query']
-    title = 'dummy title'
+    data_source = "dummy data source"
+    targets = ["dummy_prom_query"]
+    title = "dummy title"
     pie = G.PieChartv2(data_source, targets, title)
     data = pie.to_json_data()
-    assert data['targets'] == targets
-    assert data['datasource'] == data_source
-    assert data['title'] == title
-    
+    assert data["targets"] == targets
+    assert data["datasource"] == data_source
+    assert data["title"] == title
+
+
 def test_sql_target():
     t = G.Table(
-        dataSource='some data source',
+        dataSource="some data source",
         targets=[
-            G.SqlTarget(rawSql='SELECT * FROM example'),
+            G.SqlTarget(rawSql="SELECT * FROM example"),
         ],
-        title='table title'
+        title="table title",
     )
-    assert t.to_json_data()['targets'][0]["rawQuery"] == True
-    assert t.to_json_data()['targets'][0]["rawSql"] == "SELECT * FROM example"
+    assert t.to_json_data()["targets"][0].rawQuery is True
+    assert t.to_json_data()["targets"][0].rawSql == "SELECT * FROM example"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.6.0',
+    version='0.6.1',
     description='Library for building Grafana dashboards',
     long_description=open(README).read(),
     url='https://github.com/weaveworks/grafanalib',


### PR DESCRIPTION
This change is supposed to make it possible to define SQL queries as well for targets so Data Sources like MySQL, PostgreSQL can work too.

## What does this do?
Creates a New Target class named SqlTarget. With this now it is possible to define panels (Graphs) with SQL queries in them for datasources like MySQL and PostgreSQL.

## Why is it a good idea?
SQL based datasources are really widespread and with this addition now those panels can also be defined by grafanalib.

## Context
It was already mentioned in a feature request.  Feature Request: support sql queries #153 

## Questions
No questions from my side.
