### PR TITLE
alertName parameter for AlertList panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 * Added ``datasource`` parameter to CloudWatch targets
 * Added support for auto panels ids to AlertList panel
 * Added support for fields value in Stat panel
+* Added ``alertName`` parameter to AlertList panel
 
 0.6.1 (2021-11-23)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1922,6 +1922,7 @@ class AlertList(object):
         An empty list means all alerts.
     :param title: The panel title.
     :param transparent: If true, display the panel without a background.
+    :param alertName: Show only alerts that contain alertName in their name.
     """
 
     dashboardTags = attr.ib(
@@ -1947,6 +1948,7 @@ class AlertList(object):
     stateFilter = attr.ib(default=attr.Factory(list))
     title = attr.ib(default="")
     transparent = attr.ib(default=False, validator=instance_of(bool))
+    alertName = attr.ib(default="", validator=instance_of(str))
 
     def _map_panels(self, f):
         return f(self)
@@ -1968,6 +1970,9 @@ class AlertList(object):
             'title': self.title,
             'transparent': self.transparent,
             'type': ALERTLIST_TYPE,
+            "options": {
+                "alertName": self.alertName
+            },
         }
 
 


### PR DESCRIPTION
## What does this do?
Adds the ability to filter alerts in AlertList panel.
<img width="372" alt="Screenshot 2022-01-07 at 15 17 44" src="https://user-images.githubusercontent.com/3420079/148564744-eb630177-e418-41df-ae23-a5ce65b412ef.png">

## Why is it a good idea?
Because filtering doesn't work right now.

## Context
Not sure if it is because of recent Grafana version, or using new grafana alerting system, but `AlertList` panels created manually have quite different model from the ones generated by grafanalib, and not all parameters work for it.

## Questions
I don't know what is the correct course of action would be here, but for now I've just fixed one parameter that I need (hopefully in a non-breaking way).
