### PR TITLE
Add `to_json_data` for `Repeat` class

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -380,6 +380,13 @@ class Repeat(object):
     variable = attr.ib(default=None)
     maxPerRow = attr.ib(default=None, validator=is_valid_max_per_row)
 
+    def to_json_data(self):
+        return {
+            'direction': self.direction,
+            'variable': self.variable,
+            'maxPerRow': self.maxPerRow,
+        }
+
 
 def is_valid_target(instance, attribute, value):
     """


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?

Previously it wasn't possible to make a Repeat class because it couldn't be turned into JSON

## Why is it a good idea?

This makes it possible

## Context

I think this is reasonably straight forward, but I'm happy to provide more context if you have questions.

## Questions

No questions, thank you!