### PR TITLE
Add thresholdsStyleMode parameter for TimeSeries panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 * Added support for auto panels ids to AlertList panel
 * Added support for fields value in Stat panel
 * Added ``alertName`` parameter to AlertList panel
+* Added ``thresholdsStyleMode`` parameter to TimeSeries panel
 
 0.6.1 (2021-11-23)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1551,6 +1551,7 @@ class TimeSeries(Panel):
     :param tooltipMode: When you hover your cursor over the visualization, Grafana can display tooltips
         single (Default), multi, none
     :param unit: units
+    :param thresholdsStyleMode: thresholds style mode off (Default), area, line, line+area
     """
 
     axisPlacement = attr.ib(default='auto', validator=instance_of(str))
@@ -1574,6 +1575,7 @@ class TimeSeries(Panel):
     stacking = attr.ib(default={}, validator=instance_of(dict))
     tooltipMode = attr.ib(default='single', validator=instance_of(str))
     unit = attr.ib(default='', validator=instance_of(str))
+    thresholdsStyleMode = attr.ib(default='off', validator=instance_of(str))
 
     def to_json_data(self):
         return self.panel_json(
@@ -1604,6 +1606,9 @@ class TimeSeries(Panel):
                                 'tooltip': False,
                                 'viz': False,
                                 'legend': False
+                            },
+                            'thresholdsStyle': {
+                                'mode': self.thresholdsStyleMode
                             },
                         },
                         'mappings': self.mappings,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
Adds the ability to set thresholdsStyleMode in TimeSeries panel.
<img width="369" alt="スクリーンショット 2022-02-16 15 49 25" src="https://user-images.githubusercontent.com/33643470/154212607-5738dfc8-7698-40a9-bc95-355aeb320c56.png">

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
Because the threshold drawing style could not be set.

## Context
<!-- any background that might help the reviewer understand what's going on -->
In the TimeSeries panel, the threshold drawing style could not be set.

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
