### PR TITLE
add 'datasource' parameter for InfluxdbTarget

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ x.x.x (TBC)
 ===========
 
 * Added ...
+* Added datasource parameter to Influxdb targets
 
 
 0.6.3 (2022-03-30)

--- a/grafanalib/influxdb.py
+++ b/grafanalib/influxdb.py
@@ -17,6 +17,7 @@ class InfluxDBTarget(object):
 
     :param alias: legend alias
     :param format: Bucket aggregators
+    :param datasource: Influxdb name (for multiple datasource with same panel)
     :param measurement: Metric Aggregators
     :param query: query
     :param rawQuery: target reference id
@@ -25,6 +26,7 @@ class InfluxDBTarget(object):
 
     alias = attr.ib(default="")
     format = attr.ib(default=TIME_SERIES_TARGET_FORMAT)
+    datasource = attr.ib(default="")
     measurement = attr.ib(default="")
     query = attr.ib(default="")
     rawQuery = attr.ib(default=True)
@@ -35,6 +37,7 @@ class InfluxDBTarget(object):
             'query': self.query,
             'resultFormat': self.format,
             'alias': self.alias,
+            'datasource': self.datasource,
             'measurement': self.measurement,
             'rawQuery': self.rawQuery,
             'refId': self.refId


### PR DESCRIPTION
Under each InfluxdbTarget, a different data source can be specified. This allow the merging of trends from different influxb into the same Panel. This is done by adding the 'datasource' parameter to the InfluxdbTarget object

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Add a datasource for different InfluxdbTarget. Without this option, the InfluxdbTarget could only have one default datasource specify outside Target.

## Why is it a good idea?
Different datasource for each Influxdbtarget allows the merging of different trend onto the same Panel.

## Context
The current setup using dataSource specify outside the target stencils. Adding a data source within the target allows a combination of different data sources on the same panel. This is carried out via adding "datasource" parameter within the influxdbTarget object similar to adding the parameters like query and measurement. This standalone datasource is supported by grafana.

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
