### PR TITLE
Add support for Shared Tooltip on graphs (fixes #476)

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -262,6 +262,10 @@ GAUGE_DISPLAY_MODE_BASIC = 'basic'
 GAUGE_DISPLAY_MODE_LCD = 'lcd'
 GAUGE_DISPLAY_MODE_GRADIENT = 'gradient'
 
+GRAPH_TOOLTIP_MODE_NOT_SHARED = 0
+GRAPH_TOOLTIP_MODE_SHARED_CROSSHAIR = 1
+GRAPH_TOOLTIP_MODE_SHARED_TOOLTIP = 2  # Shared crosshair AND tooltip
+
 DEFAULT_AUTO_COUNT = 30
 DEFAULT_MIN_AUTO_INTERVAL = '10s'
 
@@ -1105,6 +1109,14 @@ class Dashboard(object):
         validator=instance_of(bool),
     )
     gnetId = attr.ib(default=None)
+
+    # Documented in Grafana 6.1.6, and obsoletes sharedCrosshair.  Requires a
+    # newer schema than the current default of 12.
+    graphTooltip = attr.ib(
+        default=GRAPH_TOOLTIP_MODE_NOT_SHARED,
+        validator=instance_of(int),
+    )
+
     hideControls = attr.ib(
         default=False,
         validator=instance_of(bool),
@@ -1185,6 +1197,7 @@ class Dashboard(object):
             'description': self.description,
             'editable': self.editable,
             'gnetId': self.gnetId,
+            'graphTooltip': self.graphTooltip,
             'hideControls': self.hideControls,
             'id': self.id,
             'links': self.links,


### PR DESCRIPTION
## What does this do?
Adds support for the 3rd type of graph tooltip at the dashboard level.

## Why is it a good idea?
This is a fairly common option, and closes an open issue.

## Questions

Is there a plan for managing the ever evolving schema?  I can't find where particular `schemaVersion` values are defined in Grafana, but note that the default value is in this repo is 12, whereas the current value for 8.5.2 is 36.  Looking at Grafana code, it appears that they may be changing how the schema stuff is handled (comments hinting that this field is the old way, and 36 is a "handoff" version to something else).

I realize we can't just bump the default schema without breaking users of older Grafana builds (but maybe the 12 can be bumped if that can be tied to a specific Grafana version?  Whatever version introduced 12 probably isn't supported anymore.)  However, unless the user knows to override the value when generating the dashboard, this field is ignored on import, although it is re-written to this new field and a schema of 36.  Other fields that were dropped prior to 36 are successfully migrated/ignored by Grafana, but it would be nice to not even output them in the first place- I use provisioned dashboards (so there's no import to migrate them), and it's nice to be able to compare hand generated dashboards to the code generated ones to see what's new/different.  This seems manageable in the `to_json_data()` function if fields are commented with the introducing schema.

