### PR TITLE
fix: target validation

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -391,10 +391,10 @@ class Repeat(object):
 
 def is_valid_target(instance, attribute, value):
     """
-    Check if a given attribute is a valid target
+    Check if a given attribute is a valid Target
     """
-    if not hasattr(value, "refId"):
-        raise ValueError(f"{attribute.name} should have 'refId' attribute")
+    if value.refId == "":
+        raise ValueError(f"{attribute.name} should have non-empty 'refId' attribute")
 
 
 @attr.s

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -699,6 +699,7 @@ def test_histogram():
     data = panel.to_json_data()
     assert data['options']['bucketSize'] == bucketSize
 
+
 def test_target_invalid():
     with pytest.raises(ValueError, match=r"target should have non-empty 'refId' attribute"):
         return G.AlertCondition(

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -26,7 +26,9 @@ def dummy_evaluator() -> G.Evaluator:
 
 def dummy_alert_condition() -> G.AlertCondition:
     return G.AlertCondition(
-        target=G.Target(),
+        target=G.Target(
+            refId="A",
+        ),
         evaluator=G.Evaluator(
             type=G.EVAL_GT,
             params=42),
@@ -430,7 +432,7 @@ def test_graph_panel_alert():
     targets = ['dummy_prom_query']
     title = 'dummy title'
     alert = [
-        G.AlertCondition(G.Target(), G.Evaluator('a', 'b'), G.TimeRange('5', '6'), 'd', 'e')
+        G.AlertCondition(G.Target(refId="A"), G.Evaluator('a', 'b'), G.TimeRange('5', '6'), 'd', 'e')
     ]
     thresholds = [
         G.GraphThreshold(20.0),
@@ -696,6 +698,21 @@ def test_histogram():
     panel = G.Histogram(data_source, targets, title, bucketSize=bucketSize)
     data = panel.to_json_data()
     assert data['options']['bucketSize'] == bucketSize
+
+def test_target_invalid():
+    with pytest.raises(ValueError, match=r"target should have non-empty 'refId' attribute"):
+        return G.AlertCondition(
+            target=G.Target(),
+            evaluator=G.Evaluator(
+                type=G.EVAL_GT,
+                params=42),
+            timeRange=G.TimeRange(
+                from_time='5m',
+                to_time='now'
+            ),
+            operator=G.OP_AND,
+            reducerType=G.RTYPE_AVG,
+        )
 
 
 def test_sql_target():


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Target validation requires that refId is not blank. This is because an AlertCondition needs to apply to a target refId.

However, the current validation does not work if the refId is omitted. This is because it is defaulted to "" if it's missing, but the previous check was just for `hasattr`.

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
It prevents people making invalid alerts that do not apply to any target. This could be a source of bugs.

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
