### PR TITLE
fix: add missing thresholds param to Stat json

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2067,7 +2067,7 @@ class Stat(Panel):
     reduceCalc = attr.ib(default='mean', type=str)
     fields = attr.ib(default="")
     textMode = attr.ib(default='auto')
-    thresholds = attr.ib(default="")
+    thresholds = attr.ib(default={}, type=dict)
 
     def to_json_data(self):
         return self.panel_json(
@@ -2078,7 +2078,8 @@ class Stat(Panel):
                         'decimals': self.decimals,
                         'mappings': self.mappings,
                         'unit': self.format,
-                        'noValue': self.noValue
+                        'noValue': self.noValue,
+                        'thresholds': self.thresholds,
                     },
                     'overrides': self.overrides
                 },

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -130,12 +130,16 @@ def test_stat_no_repeat():
         dataSource='data source',
         targets=[
             G.Target(expr='some expr')
-        ]
+        ],
+        thresholds={
+            "foo": "bar"
+        }
     )
 
     assert t.to_json_data()['repeat'] is None
     assert t.to_json_data()['repeatDirection'] is None
     assert t.to_json_data()['maxPerRow'] is None
+    assert t.to_json_data()['fieldConfig']['defaults']['thresholds']['foo'] is 'bar'
 
 
 def test_Text_exception_checks():


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
This adds the thresholds param (which already existed in the Stat panel's params) into the generated JSON

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
Thresholds are not applied to the generated JSON at the moment.

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
