### PR TITLE
fix: Correctly format BarGauge JSON

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2598,7 +2598,6 @@ class BarGauge(Panel):
     :param decimals: override automatic decimal precision for legend/tooltips
     :param displayMode: style to display bar gauge in
     :param format: defines value units
-    :param labels: option to show gauge level labels
     :param limit: limit of number of values to show when not Calculating
     :param max: maximum value of the gauge
     :param min: minimum value of the gauge
@@ -2626,7 +2625,6 @@ class BarGauge(Panel):
         ),
     )
     format = attr.ib(default='none')
-    label = attr.ib(default=None)
     limit = attr.ib(default=None)
     max = attr.ib(default=100)
     min = attr.ib(default=0)
@@ -2651,24 +2649,22 @@ class BarGauge(Panel):
     def to_json_data(self):
         return self.panel_json(
             {
+                'fieldConfig': {
+                    'calcs': [self.calc],
+                    'defaults': {
+                        'decimals': self.decimals,
+                        'links': self.dataLinks,
+                        'mappings': self.valueMaps,
+                        'max': self.max,
+                        'min': self.min,
+                        'unit': self.format,
+                    },
+                    'limit': self.limit,
+                    'overrides': [],
+                    'values': self.allValues,
+                },
                 'options': {
                     'displayMode': self.displayMode,
-                    'fieldOptions': {
-                        'calcs': [self.calc],
-                        'defaults': {
-                            'decimals': self.decimals,
-                            'max': self.max,
-                            'min': self.min,
-                            'title': self.label,
-                            'unit': self.format,
-                            'links': self.dataLinks,
-                        },
-                        'limit': self.limit,
-                        'mappings': self.valueMaps,
-                        'override': {},
-                        'thresholds': self.thresholds,
-                        'values': self.allValues,
-                    },
                     'orientation': self.orientation,
                     'showThresholdLabels': self.thresholdLabels,
                     'showThresholdMarkers': self.thresholdMarkers,

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -123,7 +123,6 @@ def test_table():
     assert len(t.to_json_data()['transformations']) == 2
     assert t.to_json_data()['transformations'][0]["id"] == "seriesToRows"
 
-
 def test_stat_no_repeat():
     t = G.Stat(
         title='dummy',

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -123,6 +123,7 @@ def test_table():
     assert len(t.to_json_data()['transformations']) == 2
     assert t.to_json_data()['transformations'][0]["id"] == "seriesToRows"
 
+
 def test_stat_no_repeat():
     t = G.Stat(
         title='dummy',


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
I noticed some of my params like min and max were not being applied to my dashboard. I had a look at the [grafana structs used to generate/parse the JSON](https://github.com/grafana/grafana/blob/80f6560c9c7639a3b02dd41bc1a66516903b175c/pkg/coremodel/dashboard/dashboard_gen.go#L415-L555) and it looked like a few fields were in the wrong place.

It also removes the `label` / `labels` field, because as far as I can tell the described option does not exist.

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
Corrects the structure of BarGauge so that its args are used.

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
