### PR TITLE
Add support for `statistic` field in `CloudwatchMetricsTarget`

### DIFF
--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -26,7 +26,7 @@ class CloudwatchMetricsTarget(object):
     :param period: Cloudwatch data period
     :param refId: target reference id
     :param region: Cloudwatch region
-    :param statistics: Cloudwatch mathematic statistics
+    :param statistics: Cloudwatch mathematic statistics (to be deprecated, prefer `statistic` instead)
     :param statistic: Cloudwatch mathematic statistic
     :param hide: controls if given metric is displayed on visualization
     :param datasource: Grafana datasource name

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -26,7 +26,8 @@ class CloudwatchMetricsTarget(object):
     :param period: Cloudwatch data period
     :param refId: target reference id
     :param region: Cloudwatch region
-    :param statistics: Cloudwatch mathematic statistic
+    :param statistics: Cloudwatch mathematic statistics
+    :param statistic: Cloudwatch mathematic statistic
     :param hide: controls if given metric is displayed on visualization
     :param datasource: Grafana datasource name
     """
@@ -41,6 +42,7 @@ class CloudwatchMetricsTarget(object):
     refId = attr.ib(default="")
     region = attr.ib(default="default")
     statistics = attr.ib(default=["Average"], validator=instance_of(list))
+    statistic = attr.ib(default="Average")
     hide = attr.ib(default=False, validator=instance_of(bool))
     datasource = attr.ib(default=None)
 
@@ -58,6 +60,7 @@ class CloudwatchMetricsTarget(object):
             "refId": self.refId,
             "region": self.region,
             "statistics": self.statistics,
+            "statistic": self.statistic,
             "hide": self.hide,
             "datasource": self.datasource,
         }


### PR DESCRIPTION
## What does this do?
Add support for `statistic` field in `CloudwatchMetricsTarget`

## Why is it a good idea?
The existing `statistics` field is being ignored by grafana 9.x, it must be named `statistic` (not `statistics`) and must be a string (not a list)