### PR TITLE
fix: AlertRulev9 JSON schema is not correct

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1625,15 +1625,17 @@ class AlertRulev9(object):
                 data += [trigger.to_json_data()]
 
         return {
-            "title": self.title,
             "uid": self.uid,
-            "condition": self.condition,
             "for": self.evaluateFor,
             "labels": self.labels,
             "annotations": self.annotations,
-            "data": data,
-            "noDataState": self.noDataAlertState,
-            "execErrState": self.errorAlertState
+            "grafana_alert": {
+                "title": self.title,
+                "condition": self.condition,
+                "data": data,
+                "no_data_state": self.noDataAlertState,
+                "exec_err_state": self.errorAlertState,
+            },
         }
 
 

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -901,11 +901,11 @@ def test_alertrulev9():
     )
 
     data = rule.to_json_data()
-    assert data['title'] == title
     assert data['annotations'] == annotations
     assert data['labels'] == labels
     assert data['for'] == "3m"
-    assert data['condition'] == condition
+    assert data['grafana_alert']['title'] == title
+    assert data['grafana_alert']['condition'] == condition
 
 
 def test_alertexpression():


### PR DESCRIPTION
There are a couple of mistakes in the Grafana 9 Alerts-As-Code `AlertRulev9` JSON output.

Firstly, the absence of `grafana_alert` means that uploading the output JSON fails with a validation error: `{"message":"unexpected backend type (grafana) for payload type (lotex)","traceID":""}`, which specifically is [this error in Grafana](https://github.com/grafana/grafana/blob/718620c197614f94dd15231790fc6530c3cc8b8a/pkg/services/ngalert/api/errors.go#L20-L25).

Secondly, the fields `noDataState` and `execErrState` were renamed to `no_data_state` and `exec_err_state` in v9, meaning these settings were not applied correctly.

With these changes my alerts upload successfully and appear to be correct, but if I spot further mistakes I'll make follow-up PRs.