### PR TITLE
Add support for Bar chart panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.7.1 (2022-11-14)
+===========
+
+* Added Bar_Chart_ panel support
+
+.. _Bar_Chart: basehttps://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/
+
+
 0.7.0 (2022-10-02)
 ===========
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -99,6 +99,7 @@ WORLD_MAP_TYPE = 'grafana-worldmap-panel'
 NEWS_TYPE = 'news'
 HISTOGRAM_TYPE = 'histogram'
 AE3E_PLOTLY_TYPE = 'ae3e-plotly-panel'
+BAR_CHART_TYPE = 'barchart'
 
 DEFAULT_FILL = 1
 DEFAULT_REFRESH = '10s'
@@ -4285,7 +4286,8 @@ class Ae3ePlotly(Panel):
 
 @attr.s
 class BarChart(Panel):
-    """Generates barchart panel json structure
+    """Generates bar chart panel json structure
+    Grafana docs on Bar chart panel: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/
 
     :param orientation: Controls the orientation of the chart
     :param xTickLabelRotation: Controls the rotation of bar labels
@@ -4296,7 +4298,7 @@ class BarChart(Panel):
     :param barWidth: Controls the width of the bars
     :param barRadius: Controls the radius of the bars
     :param toolTipMode: Controls the style of tooltips
-    :param toolTipSort: Controls the sort order of tooltips, when toolTipMode is "All"
+    :param toolTipSort: Controls the sort order of tooltips, when toolTipMode is 'All'
     :param showLegend: Controls the visibility of legends
     :param legendDisplayMode: Controls the style of legends, if they are shown.
     :param legendPlacement: Controls the placement of legends, if they are shown
@@ -4330,7 +4332,7 @@ class BarChart(Panel):
     tooltipSort = attr.ib(default='none', validator=instance_of(str))
     showLegend = attr.ib(default=True, validator=instance_of(bool))
     legendDisplayMode = attr.ib(default='list', validator=instance_of(str))
-    legendPlacement = attr.ib(default="bottom", validator=instance_of(str))
+    legendPlacement = attr.ib(default='bottom', validator=instance_of(str))
     legendCalcs = attr.ib(default=[], validator=instance_of(list))
     lineWidth = attr.ib(default=1, validator=instance_of(int))
     fillOpacity = attr.ib(default=80, validator=instance_of(int))
@@ -4347,24 +4349,23 @@ class BarChart(Panel):
     mappings = attr.ib(default=[], validator=instance_of(list))
     thresholdsMode = attr.ib(default='absolute', validator=instance_of(str))
     thresholdSteps = attr.ib(
-        default=[
+        default=attr.Factory(lambda: [
             {
-                "value": None,
-                "color": "green"
+                'value': None,
+                'color': 'green'
             },
             {
-                "value": 80,
-                "color": "red"
+                'value': 80,
+                'color': 'red'
             }
-        ],
+        ]),
         validator=instance_of(list)
     )
     overrides = attr.ib(default=[], validator=instance_of(list))
 
     def to_json_data(self):
-        barchart = self.panel_json(
+        bar_chart = self.panel_json(
             {
-                'type': "barchart",
                 'options': {
                     'orientation': self.orientation,
                     'xTickLabelRotation': self.xTickLabelRotation,
@@ -4415,6 +4416,7 @@ class BarChart(Panel):
                     },
                     'overrides': self.overrides
                 },
+                'type': BAR_CHART_TYPE
             }
         )
-        return barchart
+        return bar_chart

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4285,9 +4285,39 @@ class Ae3ePlotly(Panel):
 
 @attr.s
 class BarChart(Panel):
-    """Generates barchart panel json structure"""
+    """Generates barchart panel json structure
 
-    # options
+    :param orientation: Controls the orientation of the chart
+    :param xTickLabelRotation: Controls the rotation of bar labels
+    :param xTickLabelSpacing: Controls the spacing of bar labels
+    :param showValue: Controls the visibility of values
+    :param stacking: Controls the stacking of the bar chart
+    :param groupWidth: Controls the width of the group
+    :param barWidth: Controls the width of the bars
+    :param barRadius: Controls the radius of the bars
+    :param toolTipMode: Controls the style of tooltips
+    :param toolTipSort: Controls the sort order of tooltips, when toolTipMode is "All"
+    :param showLegend: Controls the visibility of legends
+    :param legendDisplayMode: Controls the style of legends, if they are shown.
+    :param legendPlacement: Controls the placement of legends, if they are shown
+    :param legendCalcs: Controls the calculations to show on legends
+    :param lineWidth: Controls the width of lines
+    :param fillOpacity: Contorls the opacity of bars
+    :param gradientMode: Controls the gradient style of the bars
+    :param axisPlacement: Controls the axis placement
+    :param axisLabel: Controls the axis labels
+    :param axisColorMode: Controls the axis color style
+    :param scaleDistributionType: Controls the type of distribution
+    :param axisCenteredZero: Center the axis
+    :param hideFromTooltip: Controls the hiding of tooltips
+    :param hideFromViz: Controls the hiding of bars
+    :param hideFromLegend: Controls the hiding of legends
+    :param colorMode: Controls the color palette of the bars
+    :param mappings: Controls the mapping of values
+    :param thresholdsMode: Controls the style threshold
+    :param thresholdSteps: Controls the treshold steps
+    :param overrides: Controls the overriding of certain datas base characteristics
+    """
     orientation = attr.ib(default='auto', validator=instance_of(str))
     xTickLabelRotation = attr.ib(default=0, validator=instance_of(int))
     xTickLabelSpacing = attr.ib(default=0, validator=instance_of(int))
@@ -4295,7 +4325,7 @@ class BarChart(Panel):
     stacking = attr.ib(default='none', validator=instance_of(str))
     groupWidth = attr.ib(default=0.7, validator=instance_of(float))
     barWidth = attr.ib(default=0.97, validator=instance_of(float))
-    barRadius = attr.ib(default=0, validator=instance_of(float))
+    barRadius = attr.ib(default=0.0, validator=instance_of(float))
     tooltipMode = attr.ib(default='single', validator=instance_of(str))
     tooltipSort = attr.ib(default='none', validator=instance_of(str))
     showLegend = attr.ib(default=True, validator=instance_of(bool))
@@ -4303,7 +4333,6 @@ class BarChart(Panel):
     legendPlacement = attr.ib(default="bottom", validator=instance_of(str))
     legendCalcs = attr.ib(default=[], validator=instance_of(list))
 
-    #fieldConfig
     lineWidth = attr.ib(default=1, validator=instance_of(int))
     fillOpacity = attr.ib(default=80, validator=instance_of(int))
     gradientMode = attr.ib(default='none', validator=instance_of(str))
@@ -4329,7 +4358,6 @@ class BarChart(Panel):
           }
         ], validator=instance_of(list))
     overrides = attr.ib(default=[], validator=instance_of(list))
-
 
     def to_json_data(self):
         barchart = self.panel_json(

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4281,3 +4281,114 @@ class Ae3ePlotly(Panel):
         _deep_update(plotly["options"]["layout"], self.layout)
         _deep_update(plotly["options"]["configuration"], self.configuration)
         return plotly
+
+
+@attr.s
+class BarChart(Panel):
+    """Generates barchart panel json structure"""
+
+    # options
+    orientation = attr.ib(default='auto', validator=instance_of(str))
+    xTickLabelRotation = attr.ib(default=0, validator=instance_of(int))
+    xTickLabelSpacing = attr.ib(default=0, validator=instance_of(int))
+    showValue = attr.ib(default='auto', validator=instance_of(str))
+    stacking = attr.ib(default='none', validator=instance_of(str))
+    groupWidth = attr.ib(default=0.7, validator=instance_of(float))
+    barWidth = attr.ib(default=0.97, validator=instance_of(float))
+    barRadius = attr.ib(default=0, validator=instance_of(float))
+    tooltipMode = attr.ib(default='single', validator=instance_of(str))
+    tooltipSort = attr.ib(default='none', validator=instance_of(str))
+    showLegend = attr.ib(default=True, validator=instance_of(bool))
+    legendDisplayMode = attr.ib(default='list', validator=instance_of(str))
+    legendPlacement = attr.ib(default="bottom", validator=instance_of(str))
+    legendCalcs = attr.ib(default=[], validator=instance_of(list))
+
+    #fieldConfig
+    lineWidth = attr.ib(default=1, validator=instance_of(int))
+    fillOpacity = attr.ib(default=80, validator=instance_of(int))
+    gradientMode = attr.ib(default='none', validator=instance_of(str))
+    axisPlacement = attr.ib(default='auto', validator=instance_of(str))
+    axisLabel = attr.ib(default='', validator=instance_of(str))
+    axisColorMode = attr.ib(default='text', validator=instance_of(str))
+    scaleDistributionType = attr.ib(default='linear', validator=instance_of(str))
+    axisCenteredZero = attr.ib(default=False, validator=instance_of(bool))
+    hideFromTooltip = attr.ib(default=False, validator=instance_of(bool))
+    hideFromViz = attr.ib(default=False, validator=instance_of(bool))
+    hideFromLegend = attr.ib(default=False, validator=instance_of(bool))
+    colorMode = attr.ib(default='palette-classic', validator=instance_of(str))
+    mappings = attr.ib(default=[], validator=instance_of(list))
+    thresholdsMode = attr.ib(default='absolute' validator=instance_of(str))
+    thresholdSteps = attr.ib(default=[
+          {
+            "value": None,
+            "color": "green"
+          },
+          {
+            "value": 80,
+            "color": "red"
+          }
+        ], validator=instance_of(list))
+    overrides = attr.ib(default=[], validator=instance_of(list))
+
+
+    def to_json_data(self):
+        barchart = self.panel_json(
+            {
+                'type': "barchart",
+                'fieldConfig':{
+                    'defaults': {},
+                    'overrides': []
+                },
+                'options': {
+                    'orientation': self.orientation,
+                    'xTickLabelRotation': self.xTickLabelRotation,
+                    'xTickLabelSpacing': self.xTickLabelSpacing,
+                    'showValue': self.showValue,
+                    'stacking': self.stacking,
+                    'groupWidth': self.groupWidth,
+                    'barWidth': self.barWidth,
+                    'barRadius': self.barRadius,
+                    'tooltip': {
+                        'mode': self.tooltipMode,
+                        'sort': self.tooltipSort
+                    },
+                    'legend': {
+                        'showLegend': self.showLegend,
+                        'displayMode': self.legendDisplayMode,
+                        'placement': self.legendPlacement,
+                        'calcs': self.legendCalcs
+                    },
+                    'fieldConfig': {
+                        'defaults': {
+                            'custom': {
+                                'lineWidth': self.lineWidth,
+                                'fillOpacity': self.fillOpacity,
+                                'gradientMode': self.gradientMode,
+                                'axisPlacement': self.axisPlacement,
+                                'axisLabel': self.axisLabel,
+                                'axisColorMode': self.axisColorMode,
+                                'scaleDistribution': {
+                                    'type': self.scaleDistributionType
+                                },
+                                'axisCenteredZero': self.axisCenteredZero,
+                                'hideFrom': {
+                                    'tooltip': self.hideFromTooltip,
+                                    'viz': self.hideFromViz,
+                                    'legend': self.hideFromLegend
+                                }
+                            },
+                            'color': {
+                                'mode': self.colorMode
+                            },
+                            'mappings': self.mappings,
+                            'thresholds': {
+                                'mode': self.thresholdsMode,
+                                'steps': self.thresholdSteps
+                            }
+                        },
+                        'overrides': self.overrides
+                    }
+                },
+            }
+        )
+        return barchart

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4310,7 +4310,7 @@ class BarChart(Panel):
     :param axisLabel: Controls the axis labels
     :param axisColorMode: Controls the axis color style
     :param scaleDistributionType: Controls the type of distribution
-    :param axisCenteredZero: Center the axis
+    :param axisCenteredZero: Controls the centering of the axis
     :param hideFromTooltip: Controls the hiding of tooltips
     :param hideFromViz: Controls the hiding of bars
     :param hideFromLegend: Controls the hiding of legends

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4332,7 +4332,6 @@ class BarChart(Panel):
     legendDisplayMode = attr.ib(default='list', validator=instance_of(str))
     legendPlacement = attr.ib(default="bottom", validator=instance_of(str))
     legendCalcs = attr.ib(default=[], validator=instance_of(list))
-
     lineWidth = attr.ib(default=1, validator=instance_of(int))
     fillOpacity = attr.ib(default=80, validator=instance_of(int))
     gradientMode = attr.ib(default='none', validator=instance_of(str))
@@ -4347,16 +4346,19 @@ class BarChart(Panel):
     colorMode = attr.ib(default='palette-classic', validator=instance_of(str))
     mappings = attr.ib(default=[], validator=instance_of(list))
     thresholdsMode = attr.ib(default='absolute', validator=instance_of(str))
-    thresholdSteps = attr.ib(default=[
-          {
-            "value": None,
-            "color": "green"
-          },
-          {
-            "value": 80,
-            "color": "red"
-          }
-        ], validator=instance_of(list))
+    thresholdSteps = attr.ib(
+        default=[
+            {
+                "value": None,
+                "color": "green"
+            },
+            {
+                "value": 80,
+                "color": "red"
+            }
+        ],
+        validator=instance_of(list)
+    )
     overrides = attr.ib(default=[], validator=instance_of(list))
 
     def to_json_data(self):

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4315,6 +4315,7 @@ class BarChart(Panel):
     :param hideFromViz: Controls the hiding of bars
     :param hideFromLegend: Controls the hiding of legends
     :param colorMode: Controls the color palette of the bars
+    :param fixedColor: Controls the color of the bars, when the colorMode is fixed
     :param mappings: Controls the mapping of values
     :param thresholdsMode: Controls the style threshold
     :param thresholdSteps: Controls the treshold steps
@@ -4346,6 +4347,7 @@ class BarChart(Panel):
     hideFromViz = attr.ib(default=False, validator=instance_of(bool))
     hideFromLegend = attr.ib(default=False, validator=instance_of(bool))
     colorMode = attr.ib(default='palette-classic', validator=instance_of(str))
+    fixedColor = attr.ib(default='blue', validator=instance_of(str))
     mappings = attr.ib(default=[], validator=instance_of(list))
     thresholdsMode = attr.ib(default='absolute', validator=instance_of(str))
     thresholdSteps = attr.ib(
@@ -4406,7 +4408,8 @@ class BarChart(Panel):
                             }
                         },
                         'color': {
-                            'mode': self.colorMode
+                            'mode': self.colorMode,
+                            'fixedColor': self.fixedColor if self.colorMode == 'fixed' else 'none'
                         },
                         'mappings': self.mappings,
                         'thresholds': {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4335,10 +4335,6 @@ class BarChart(Panel):
         barchart = self.panel_json(
             {
                 'type': "barchart",
-                'fieldConfig':{
-                    'defaults': {},
-                    'overrides': []
-                },
                 'options': {
                     'orientation': self.orientation,
                     'xTickLabelRotation': self.xTickLabelRotation,
@@ -4358,36 +4354,36 @@ class BarChart(Panel):
                         'placement': self.legendPlacement,
                         'calcs': self.legendCalcs
                     },
-                    'fieldConfig': {
-                        'defaults': {
-                            'custom': {
-                                'lineWidth': self.lineWidth,
-                                'fillOpacity': self.fillOpacity,
-                                'gradientMode': self.gradientMode,
-                                'axisPlacement': self.axisPlacement,
-                                'axisLabel': self.axisLabel,
-                                'axisColorMode': self.axisColorMode,
-                                'scaleDistribution': {
-                                    'type': self.scaleDistributionType
-                                },
-                                'axisCenteredZero': self.axisCenteredZero,
-                                'hideFrom': {
-                                    'tooltip': self.hideFromTooltip,
-                                    'viz': self.hideFromViz,
-                                    'legend': self.hideFromLegend
-                                }
+                },
+                'fieldConfig': {
+                    'defaults': {
+                        'custom': {
+                            'lineWidth': self.lineWidth,
+                            'fillOpacity': self.fillOpacity,
+                            'gradientMode': self.gradientMode,
+                            'axisPlacement': self.axisPlacement,
+                            'axisLabel': self.axisLabel,
+                            'axisColorMode': self.axisColorMode,
+                            'scaleDistribution': {
+                                'type': self.scaleDistributionType
                             },
-                            'color': {
-                                'mode': self.colorMode
-                            },
-                            'mappings': self.mappings,
-                            'thresholds': {
-                                'mode': self.thresholdsMode,
-                                'steps': self.thresholdSteps
+                            'axisCenteredZero': self.axisCenteredZero,
+                            'hideFrom': {
+                                'tooltip': self.hideFromTooltip,
+                                'viz': self.hideFromViz,
+                                'legend': self.hideFromLegend
                             }
                         },
-                        'overrides': self.overrides
-                    }
+                        'color': {
+                            'mode': self.colorMode
+                        },
+                        'mappings': self.mappings,
+                        'thresholds': {
+                            'mode': self.thresholdsMode,
+                            'steps': self.thresholdSteps
+                        }
+                    },
+                    'overrides': self.overrides
                 },
             }
         )

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -4317,7 +4317,7 @@ class BarChart(Panel):
     hideFromLegend = attr.ib(default=False, validator=instance_of(bool))
     colorMode = attr.ib(default='palette-classic', validator=instance_of(str))
     mappings = attr.ib(default=[], validator=instance_of(list))
-    thresholdsMode = attr.ib(default='absolute' validator=instance_of(str))
+    thresholdsMode = attr.ib(default='absolute', validator=instance_of(str))
     thresholdSteps = attr.ib(default=[
           {
             "value": None,

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1105,8 +1105,8 @@ def test_barchart():
     panel = G.BarChart(data_source, targets, title, orientation='horizontal', axisCenteredZero=True, showLegend=False)
     data = panel.to_json_data()
     assert data["options"]["orientation"] == 'horizontal'
-    assert data["fieldConfig"]["defaults"]["custom"]["axisCenteredZero"] == True
-    assert data["options"]["legend"]["showLegend"] == False
+    assert data["fieldConfig"]["defaults"]["custom"]["axisCenteredZero"]
+    assert not data["options"]["legend"]["showLegend"]
 
 
 def test_target_invalid():

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1088,6 +1088,31 @@ def test_ae3e_plotly():
     assert data["options"]["layout"] == layout
 
 
+def test_barchart():
+    data_source = "dummy data source"
+    targets = ["dummy_prom_query"]
+    title = "dummy title"
+    panel = G.BarChart(data_source, targets, title)
+    data = panel.to_json_data()
+    
+    assert data["targets"] == targets
+    assert data["datasource"] == data_source
+    assert data["title"] == title
+
+    assert data["options"] is not None
+    assert data["fieldConfig"] is not None
+
+    assert data["options"]["orientation"] == 'auto'
+    assert data["fieldConfig"]["color"] == 'palette-classic'
+
+    panel = G.BarChart(data_source, targets, title, orientation='horizontal', axisCenteredZero=True, showLegend=False)
+    data = panel.to_json_data()
+
+    assert data["options"]["orientation"] == 'horizontal'
+    assert data["options"]["axisCenteredZero"] == True
+    assert data["options"]["legend"]["showLegend"] == False
+
+
 def test_target_invalid():
     with pytest.raises(ValueError, match=r"target should have non-empty 'refId' attribute"):
         return G.AlertCondition(

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1094,20 +1094,16 @@ def test_barchart():
     title = "dummy title"
     panel = G.BarChart(data_source, targets, title)
     data = panel.to_json_data()
-
     assert data["targets"] == targets
     assert data["datasource"] == data_source
     assert data["title"] == title
-
     assert data["options"] is not None
     assert data["fieldConfig"] is not None
-
     assert data["options"]["orientation"] == 'auto'
     assert data["fieldConfig"]["defaults"]["color"]["mode"] == 'palette-classic'
 
     panel = G.BarChart(data_source, targets, title, orientation='horizontal', axisCenteredZero=True, showLegend=False)
     data = panel.to_json_data()
-
     assert data["options"]["orientation"] == 'horizontal'
     assert data["fieldConfig"]["defaults"]["custom"]["axisCenteredZero"] == True
     assert data["options"]["legend"]["showLegend"] == False

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1094,7 +1094,7 @@ def test_barchart():
     title = "dummy title"
     panel = G.BarChart(data_source, targets, title)
     data = panel.to_json_data()
-    
+
     assert data["targets"] == targets
     assert data["datasource"] == data_source
     assert data["title"] == title
@@ -1103,13 +1103,13 @@ def test_barchart():
     assert data["fieldConfig"] is not None
 
     assert data["options"]["orientation"] == 'auto'
-    assert data["fieldConfig"]["color"] == 'palette-classic'
+    assert data["fieldConfig"]["defaults"]["color"]["mode"] == 'palette-classic'
 
     panel = G.BarChart(data_source, targets, title, orientation='horizontal', axisCenteredZero=True, showLegend=False)
     data = panel.to_json_data()
 
     assert data["options"]["orientation"] == 'horizontal'
-    assert data["options"]["axisCenteredZero"] == True
+    assert data["fieldConfig"]["defaults"]["custom"]["axisCenteredZero"] == True
     assert data["options"]["legend"]["showLegend"] == False
 
 


### PR DESCRIPTION
## What does this do?
Add support for [Bar chart panel](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/).

## Why is it a good idea?
Add support for a new, useful panel type.

## Context
The panel allows you to graph categorical data. It supports only one data frame, and it must have at least one string field that will be used as the category for an X or Y axis and one or more numerical fields.

Closes #510 