### PR TITLE
Expose Now delay option in TimePicker

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1055,10 +1055,15 @@ class TimePicker(object):
 
     :param refreshIntervals: dashboard auto-refresh interval options
     :param timeOptions: dashboard time range options
+    :param nowDelay: exclude recent data that may be incomplete, as a
+        number + unit (s: second, m: minute, h: hour, etc)
     :param hidden: hide the time picker from dashboard
     """
     refreshIntervals = attr.ib()
     timeOptions = attr.ib()
+    nowDelay = attr.ib(
+        default=None,
+    )
     hidden = attr.ib(
         default=False,
         validator=instance_of(bool),
@@ -1068,6 +1073,7 @@ class TimePicker(object):
         return {
             'refresh_intervals': self.refreshIntervals,
             'time_options': self.timeOptions,
+            'nowDelay': self.nowDelay,
             'hidden': self.hidden
         }
 


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->

The Now delay can be applied to a dashboard (via a TimePicker), which will delay the time at which `now` applies when looking at data on a dashboard.
<img width="244" alt="image" src="https://user-images.githubusercontent.com/7999692/204106942-21f5fda4-8bc5-449b-9012-67254ca21157.png">

<img width="167" alt="image" src="https://user-images.githubusercontent.com/7999692/204106966-771594b9-bffd-4bb7-8501-2e3a64616048.png">

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

This was missing from Grafanalib.