### PR TITLE
Update SqlTarget to support parsing queries from files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+0.7.x (xxxx-xx-xx)
+===========
+
+* Extended SqlTarget to support parsing queries from files
+
+
 0.7.0 (2022-10-02)
 ===========
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -608,6 +608,20 @@ class SqlTarget(Target):
 
     rawSql = attr.ib(default="")
     rawQuery = attr.ib(default=True)
+    srcFilePath = attr.ib(default="", validator=instance_of(str))
+    sqlParams = attr.ib(default={}, validator=instance_of(dict))
+
+    def __attrs_post_init__(self):
+        """Override rawSql if a path to a source file is provided,
+        if it is a parameterized query, fill in the parameters.
+        srcFilePath: this will containt the path to the source file
+        sqlParams: this will contain the sql parameters to use in the read query
+        """
+        if self.srcFilePath:
+            with open(self.srcFilePath, "r") as f:
+                self.rawSql = f.read()
+                if self.sqlParams is not None:
+                    self.rawSql = self.rawSql.format(**self.sqlParams)
 
     def to_json_data(self):
         """Override the Target to_json_data to add additional fields.

--- a/grafanalib/tests/examples/sqltarget_example_files/example.sql
+++ b/grafanalib/tests/examples/sqltarget_example_files/example.sql
@@ -1,3 +1,3 @@
-SELECT repo, count(id)
+SELECT example, count(id)
 FROM test
-GROUP BY repo;
+GROUP BY example;

--- a/grafanalib/tests/examples/sqltarget_example_files/example.sql
+++ b/grafanalib/tests/examples/sqltarget_example_files/example.sql
@@ -1,0 +1,3 @@
+SELECT repo, count(id)
+FROM test
+GROUP BY repo;

--- a/grafanalib/tests/examples/sqltarget_example_files/example_with_params.sql
+++ b/grafanalib/tests/examples/sqltarget_example_files/example_with_params.sql
@@ -1,3 +1,3 @@
-SELECT name
+SELECT example
 FROM test
-WHERE name='{name}' AND commit_date BETWEEN '{starting_date}' AND '{ending_date}';
+WHERE example='{example}' AND example_date BETWEEN '{starting_date}' AND '{ending_date}';

--- a/grafanalib/tests/examples/sqltarget_example_files/example_with_params.sql
+++ b/grafanalib/tests/examples/sqltarget_example_files/example_with_params.sql
@@ -1,0 +1,3 @@
+SELECT name
+FROM test
+WHERE name='{name}' AND commit_date BETWEEN '{starting_date}' AND '{ending_date}';

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1125,14 +1125,14 @@ def test_sql_target_with_source_files():
         title="table title",
     )
     assert t.to_json_data()["targets"][0].rawQuery is True
-    assert t.to_json_data()["targets"][0].rawSql == "SELECT repo, count(id)\nFROM test\nGROUP BY repo;\n"
+    assert t.to_json_data()["targets"][0].rawSql == "SELECT example, count(id)\nFROM test\nGROUP BY example;\n"
     print(t.to_json_data()["targets"][0])
 
     t = G.Table(
         dataSource="some data source",
         targets=[
             G.SqlTarget(srcFilePath="grafanalib/tests/examples/sqltarget_example_files/example_with_params.sql", sqlParams={
-                "name": "example",
+                "example": "example",
                 "starting_date": "1970-01-01",
                 "ending_date": "1971-01-01",
             },),
@@ -1140,5 +1140,5 @@ def test_sql_target_with_source_files():
         title="table title",
     )
     assert t.to_json_data()["targets"][0].rawQuery is True
-    assert t.to_json_data()["targets"][0].rawSql == "SELECT name\nFROM test\nWHERE name='example' AND commit_date BETWEEN '1970-01-01' AND '1971-01-01';\n"
+    assert t.to_json_data()["targets"][0].rawSql == "SELECT example\nFROM test\nWHERE example='example' AND example_date BETWEEN '1970-01-01' AND '1971-01-01';\n"
     print(t.to_json_data()["targets"][0])

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1114,3 +1114,31 @@ def test_sql_target():
     )
     assert t.to_json_data()["targets"][0].rawQuery is True
     assert t.to_json_data()["targets"][0].rawSql == "SELECT * FROM example"
+
+
+def test_sql_target_with_source_files():
+    t = G.Table(
+        dataSource="some data source",
+        targets=[
+            G.SqlTarget(srcFilePath="grafanalib/tests/examples/sqltarget_example_files/example.sql"),
+        ],
+        title="table title",
+    )
+    assert t.to_json_data()["targets"][0].rawQuery is True
+    assert t.to_json_data()["targets"][0].rawSql == "SELECT repo, count(id)\nFROM test\nGROUP BY repo;\n"
+    print(t.to_json_data()["targets"][0])
+
+    t = G.Table(
+        dataSource="some data source",
+        targets=[
+            G.SqlTarget(srcFilePath="grafanalib/tests/examples/sqltarget_example_files/example_with_params.sql", sqlParams={
+                "name": "example",
+                "starting_date": "1970-01-01",
+                "ending_date": "1971-01-01",
+            },),
+        ],
+        title="table title",
+    )
+    assert t.to_json_data()["targets"][0].rawQuery is True
+    assert t.to_json_data()["targets"][0].rawSql == "SELECT name\nFROM test\nWHERE name='example' AND commit_date BETWEEN '1970-01-01' AND '1971-01-01';\n"
+    print(t.to_json_data()["targets"][0])


### PR DESCRIPTION
## What does this do?
Add the ability to parse SQL queries from files.

## Why is it a good idea?
Parsing files instead of using query strings reduces code length and improves code readability.

## Context
Complex panels and dashboards use multiple long queries. Parsing them from files shortens the code length and leads to a more readable and maintainable codebase. The implementation supports parametrizing the queries with dictionary as an attribute to help writing queries with variables.