### PR TITLE
fix: AlertRulev9 does not support CloudwatchMetricsTarget

### DIFF
--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -3,10 +3,11 @@
 import attr
 
 from attr.validators import instance_of
+from grafanalib.core import Target
 
 
 @attr.s
-class CloudwatchMetricsTarget(object):
+class CloudwatchMetricsTarget(Target):
     """
     Generates Cloudwatch target JSON structure.
 

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -65,7 +65,7 @@ class CloudwatchMetricsTarget(Target):
 
 
 @attr.s
-class CloudwatchLogsInsightsTarget(object):
+class CloudwatchLogsInsightsTarget(Target):
     """
     Generates Cloudwatch Logs Insights target JSON structure.
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1625,15 +1625,17 @@ class AlertRulev9(object):
                 data += [trigger.to_json_data()]
 
         return {
-            "title": self.title,
             "uid": self.uid,
-            "condition": self.condition,
             "for": self.evaluateFor,
             "labels": self.labels,
             "annotations": self.annotations,
-            "data": data,
-            "noDataState": self.noDataAlertState,
-            "execErrState": self.errorAlertState
+            "grafana_alert": {
+                "title": self.title,
+                "condition": self.condition,
+                "data": data,
+                "no_data_state": self.noDataAlertState,
+                "exec_err_state": self.errorAlertState,
+            },
         }
 
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1310,7 +1310,8 @@ class AlertExpression(object):
         for condition in self.conditions:
             # discard unused features of condition as of grafana 8.x
             condition.useNewAlerts = True
-            condition.target = Target(refId=self.expression)
+            if condition.target is None:
+                condition.target = Target(refId=self.expression)
             conditions += [condition.to_json_data()]
 
         expression = {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1432,7 +1432,7 @@ def is_valid_triggersv9(instance, attribute, value):
     """Validator for AlertRule triggers for Grafana v9"""
     for trigger in value:
         if not (isinstance(trigger, Target) or isinstance(trigger, AlertExpression)):
-            raise ValueError(f"{attribute.name} must either be a Target or AlertCondition")
+            raise ValueError(f"{attribute.name} must either be a Target or AlertExpression")
 
         if isinstance(trigger, Target):
             is_valid_target(instance, "alert trigger target", trigger)

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -901,11 +901,11 @@ def test_alertrulev9():
     )
 
     data = rule.to_json_data()
-    assert data['title'] == title
     assert data['annotations'] == annotations
     assert data['labels'] == labels
     assert data['for'] == "3m"
-    assert data['condition'] == condition
+    assert data['grafana_alert']['title'] == title
+    assert data['grafana_alert']['condition'] == condition
 
 
 def test_alertexpression():


### PR DESCRIPTION
## What does this do?
Some small fixes for Grafana 9 alerts support:
- Grafana9 AlertExpression accepts only Targets while CloudwatchMetricsTarget for some reason is not a Target
- AlertCondition can include multiple conditions, each with its own target

## Why is it a good idea?
- Maintain support for CloudwatchMetricsTarget in alerts
- Support the full complexity of the implementation of the new alert
