### PR TITLE
Fix rendering AlertRulev9 json for possible use in Alerting provisioning API

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -842,18 +842,9 @@ class DataSourceInput(object):
 
 
 @attr.s
-class DataSourceForTargets(object):
+class DataSource(object):
     uid = attr.ib(validator=instance_of(str))
-    type = attr.ib(
-        validator=in_([
-            PLUGIN_ID_CLOUDWATCH,
-            PLUGIN_ID_GRAPHITE,
-            PLUGIN_ID_INFLUXDB,
-            PLUGIN_ID_OPENTSDB,
-            PLUGIN_ID_PROMETHEUS,
-            PLUGIN_ID_ELASTICSEARCH,
-        ])
-    )
+    type = attr.ib(validator=instance_of(str))
 
     def to_json_data(self):
         return {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1600,8 +1600,8 @@ class AlertRulev9(object):
 
     title = attr.ib()
     triggers = attr.ib(default=[], validator=is_valid_triggersv9)
-    annotations = attr.ib(default={}, validator=instance_of(dict))
-    labels = attr.ib(default={}, validator=instance_of(dict))
+    annotations = attr.ib(factory=dict, validator=instance_of(dict))
+    labels = attr.ib(factory=dict, validator=instance_of(dict))
     folderUid = attr.ib(default=None, validator=attr.validators.optional(instance_of(str)))
     ruleGroup = attr.ib(default=None, validator=attr.validators.optional(instance_of(str)))
 
@@ -1626,8 +1626,8 @@ class AlertRulev9(object):
     timeRangeFrom = attr.ib(default=300, validator=instance_of(int))
     timeRangeTo = attr.ib(default=0, validator=instance_of(int))
     uid = attr.ib(default=None, validator=attr.validators.optional(instance_of(str)))
-    dashboard_uid = attr.ib(default="", validator=instance_of(str))
-    panel_id = attr.ib(default=0, validator=instance_of(int))
+    dashboard_uid = attr.ib(default=None, validator=attr.validators.optional(instance_of(str)))
+    panel_id = attr.ib(default=None, validator=attr.validators.optional(instance_of(int)))
 
     def to_json_data(self):
         data = []
@@ -1647,10 +1647,10 @@ class AlertRulev9(object):
             else:
                 data += [trigger.to_json_data()]
 
-        if self.panel_id and '__panelId__' not in self.annotations:
+        if self.panel_id:
             self.annotations['__panelId__'] = str(self.panel_id)
 
-        if self.dashboard_uid and '__dashboardUid__' not in self.annotations:
+        if self.dashboard_uid:
             self.annotations['__dashboardUid__'] = self.dashboard_uid
 
         return {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1602,6 +1602,8 @@ class AlertRulev9(object):
     triggers = attr.ib(default=[], validator=is_valid_triggersv9)
     annotations = attr.ib(default={}, validator=instance_of(dict))
     labels = attr.ib(default={}, validator=instance_of(dict))
+    folderUid = attr.ib(default=None, validator=attr.validators.optional(instance_of(str)))
+    ruleGroup = attr.ib(default=None, validator=attr.validators.optional(instance_of(str)))
 
     evaluateFor = attr.ib(default=DEFAULT_ALERT_EVALUATE_FOR, validator=instance_of(str))
     noDataAlertState = attr.ib(
@@ -1660,7 +1662,9 @@ class AlertRulev9(object):
             "annotations": self.annotations,
             "data": data,
             "noDataState": self.noDataAlertState,
-            "execErrState": self.errorAlertState
+            "execErrState": self.errorAlertState,
+            "folderUid": self.folderUid,
+            "ruleGroup": self.ruleGroup,
         }
 
 


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?

This PR fix generates the correct json for HTTP API requests.

1. Add link alert with dashboard and panel. In AlertRulev9 class exist params `panel_id` and `dashboard_uid` but didn't use in json generating.
2. Fix defaults for `labels` and `annotations` params because are work incorrectly. If I change param in one alert is changed in all
```
>>> import attr
>>> @attr.s
... class X:
...     d = attr.ib(default={})
...
>>> a = X()
>>> b = X()
>>> a.d['test']='test'
>>> b
X(d={'test': 'test'})
>>>
```

3. Add DataSource class for correct generating targets in alert_rule, because API need this struct

```

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
