### PR TITLE
Add support for Elasticsearch Rate Metric Aggregator

### DIFF
--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -2,7 +2,7 @@
 
 import attr
 import itertools
-from attr.validators import instance_of
+from attr.validators import in_, instance_of
 from grafanalib.core import AlertCondition
 
 DATE_HISTOGRAM_DEFAULT_FIELD = 'time_iso8601'

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -499,6 +499,7 @@ class PercentilesMetricAgg(object):
             'settings': self.settings,
         }
 
+
 @attr.s
 class RateMetricAgg(object):
     """An aggregator that provides the rate of the values.

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -498,3 +498,48 @@ class PercentilesMetricAgg(object):
             'inlineScript': self.inline,
             'settings': self.settings,
         }
+
+@attr.s
+class RateMetricAgg(object):
+    """An aggregator that provides the rate of the values.
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html
+    :param field: name of elasticsearch field to provide the sum over
+    :param hide: show/hide the metric in the final panel display
+    :param id: id of the metric
+    :param unit: calendar interval to group by
+        supported calendar intervals
+        https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#calendar_intervals
+        "minute"
+        "hour"
+        "day"
+        "week"
+        "month"
+        "quarter"
+        "year"
+    :param mode: sum or count the values
+    :param script: script to apply to the data, using '_value'
+    """
+
+    field = attr.ib(default="", validator=instance_of(str))
+    id = attr.ib(default=0, validator=instance_of(int))
+    hide = attr.ib(default=False, validator=instance_of(bool))
+    unit = attr.ib(default="", validator=instance_of(str))
+    mode = attr.ib(default="", validator=in_(["", "value_count", "sum"]))
+    script = attr.ib(default="", validator=instance_of(str))
+
+    def to_json_data(self):
+        self.settings = {}
+
+        if self.mode:
+            self.settings["mode"] = self.mode
+
+        if self.script:
+            self.settings["script"] = self.script
+
+        return {
+            "id": str(self.id),
+            "hide": self.hide,
+            "field": self.field,
+            "settings": self.settings,
+            "type": "rate",
+        }


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
This adds support for the "Rate Aggregation" as a metric in an Elasticsearch query.

![image](https://user-images.githubusercontent.com/3618494/236653410-4d2354d6-a69f-49de-84eb-dfb0fc50762f.png)


## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
This is supported in Grafana, and my team needed it for something. I figure others might too.

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
