### PR TITLE
Add color support in Stat(panel)

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2730,7 +2730,7 @@ class Stat(Panel):
             {
                 'fieldConfig': {
                     'defaults': {
-						'color': self.color,
+                        'color': self.color,
                         'custom': {},
                         'decimals': self.decimals,
                         'mappings': self.mappings,

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2711,6 +2711,7 @@ class Stat(Panel):
     """
 
     alignment = attr.ib(default='auto')
+    color = attr.ib(default=None)
     colorMode = attr.ib(default='value')
     decimals = attr.ib(default=None)
     format = attr.ib(default='none')
@@ -2729,6 +2730,7 @@ class Stat(Panel):
             {
                 'fieldConfig': {
                     'defaults': {
+						'color': self.color,
                         'custom': {},
                         'decimals': self.decimals,
                         'mappings': self.mappings,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Currently Stat(panel) doesn't support color option, so it still always be grey color when using Stat(panel)

## Why is it a good idea?
Have a choice of color improve the readable of panel

## Context
Color option is simpler than thresholds, in the case of no need to define thresholds

## Questions
not sure about the combination, in my case, I always use together with colorMode="background" and graphMode="none"
