### PR TITLE
add unit to tables and hide flag to es targets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Changelog
 .. _`Bar_Chart`: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/
 .. _`RateMetricAgg`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html
 
+* Added unit parameter to the Table class in core
+* Added a hide parameter to ElasticsearchTarget
+
 0.7.0 (2022-10-02)
 ==================
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3194,6 +3194,7 @@ class Table(Panel):
     :param mappings: To assign colors to boolean or string values, use Value mappings
     :param overrides: To override the base characteristics of certain data
     :param showHeader: Show the table header
+    :param unit: units
     """
 
     align = attr.ib(default='auto', validator=instance_of(str))
@@ -3205,7 +3206,8 @@ class Table(Panel):
     mappings = attr.ib(default=attr.Factory(list))
     overrides = attr.ib(default=attr.Factory(list))
     showHeader = attr.ib(default=True, validator=instance_of(bool))
-    span = attr.ib(default=6)
+    span = attr.ib(default=6),
+    unit = attr.ib(default='', validator=instance_of(str))
 
     @classmethod
     def with_styled_columns(cls, columns, styles=None, **kwargs):
@@ -3227,8 +3229,9 @@ class Table(Panel):
                         'custom': {
                             'align': self.align,
                             'displayMode': self.displayMode,
-                            'filterable': self.filterable
+                            'filterable': self.filterable,
                         },
+                        'unit': self.unit
                     },
                     'overrides': self.overrides
                 },

--- a/grafanalib/elasticsearch.py
+++ b/grafanalib/elasticsearch.py
@@ -363,6 +363,7 @@ class ElasticsearchTarget(object):
     :param query: query
     :param refId: target reference id
     :param timeField: name of the elasticsearch time field
+    :param hide: show/hide the target result in the final panel display
     """
 
     alias = attr.ib(default=None)
@@ -373,6 +374,7 @@ class ElasticsearchTarget(object):
     query = attr.ib(default="", validator=instance_of(str))
     refId = attr.ib(default="", validator=instance_of(str))
     timeField = attr.ib(default="@timestamp", validator=instance_of(str))
+    hide = attr.ib(default=False, validator=instance_of(bool))
 
     def _map_bucket_aggs(self, f):
         return attr.evolve(self, bucketAggs=list(map(f, self.bucketAggs)))
@@ -407,6 +409,7 @@ class ElasticsearchTarget(object):
             'query': self.query,
             'refId': self.refId,
             'timeField': self.timeField,
+            'hide': self.hide,
         }
 
 


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
- Added a units parameter to core.Table.
- Added a hide flag to ElasticsearchTarget.

## Why is it a good idea?
- Allows to display table entries as units of time/bytes/anything else.
- ElasticsearchTarget is responsible for query results, so it is essential to be able to choose which ones to display with composite queries. For example if we want to display the ratio between two sums but not to see the sums.
