### PR TITLE
fix:unknown NoData state option for alertrulev9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 * Extended SqlTarget to support parsing queries from files
 * Fix AlertCondition backwards compatibility (``useNewAlerts`` default to ``False``)
 * Added RateMetricAgg_ for ElasticSearch
+* Fix AlertRuleV9 "unknown NoData state option No Data"
 
 .. _`Bar_Chart`: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/
 .. _`RateMetricAgg`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -251,6 +251,12 @@ ALERTRULE_STATE_DATA_NODATA = 'No Data'
 ALERTRULE_STATE_DATA_ALERTING = 'Alerting'
 ALERTRULE_STATE_DATA_ERROR = 'Error'
 
+# Alert Rule state filter options (Grafana 9.x)
+ALERTRULEV9_STATE_DATA_OK = 'OK'
+ALERTRULEV9_STATE_DATA_NODATA = 'NoData'
+ALERTRULEV9_STATE_DATA_ALERTING = 'Alerting'
+ALERTRULEV9_STATE_DATA_ERROR = 'Error'
+
 # Display Sort Order
 SORT_ASC = 1
 SORT_DESC = 2
@@ -1591,10 +1597,10 @@ class AlertRulev9(object):
         The Interval is set by the alert group
     :param noDataAlertState: Alert state if no data or all values are null
         Must be one of the following:
-        [ALERTRULE_STATE_DATA_OK, ALERTRULE_STATE_DATA_ALERTING, ALERTRULE_STATE_DATA_NODATA ]
+        [ALERTRULEV9_STATE_DATA_OK, ALERTRULEV9_STATE_DATA_ALERTING, ALERTRULEV9_STATE_DATA_NODATA]
     :param errorAlertState: Alert state if execution error or timeout
         Must be one of the following:
-        [ALERTRULE_STATE_DATA_OK, ALERTRULE_STATE_DATA_ALERTING, ALERTRULE_STATE_DATA_ERROR ]
+        [ALERTRULEV9_STATE_DATA_OK, ALERTRULEV9_STATE_DATA_ALERTING, ALERTRULEV9_STATE_DATA_ERROR ]
 
     :param timeRangeFrom: Time range interpolation data start from
     :param timeRangeTo: Time range interpolation data finish at
@@ -1610,19 +1616,19 @@ class AlertRulev9(object):
 
     evaluateFor = attr.ib(default=DEFAULT_ALERT_EVALUATE_FOR, validator=instance_of(str))
     noDataAlertState = attr.ib(
-        default=ALERTRULE_STATE_DATA_ALERTING,
+        default=ALERTRULEV9_STATE_DATA_ALERTING,
         validator=in_([
-            ALERTRULE_STATE_DATA_OK,
-            ALERTRULE_STATE_DATA_ALERTING,
-            ALERTRULE_STATE_DATA_NODATA
+            ALERTRULEV9_STATE_DATA_OK,
+            ALERTRULEV9_STATE_DATA_ALERTING,
+            ALERTRULEV9_STATE_DATA_NODATA
         ])
     )
     errorAlertState = attr.ib(
-        default=ALERTRULE_STATE_DATA_ALERTING,
+        default=ALERTRULEV9_STATE_DATA_ALERTING,
         validator=in_([
-            ALERTRULE_STATE_DATA_OK,
-            ALERTRULE_STATE_DATA_ALERTING,
-            ALERTRULE_STATE_DATA_ERROR
+            ALERTRULEV9_STATE_DATA_OK,
+            ALERTRULEV9_STATE_DATA_ALERTING,
+            ALERTRULEV9_STATE_DATA_ERROR
         ])
     )
     condition = attr.ib(default='B')


### PR DESCRIPTION
## What does this do?
Fixes problem with AlertRuleV9 `unknown NoData state option No Data`. Details here: https://github.com/weaveworks/grafanalib/issues/601

## Why is it a good idea?
It covers important part of alert rule configuration.

## Context
I've run into the same issue as: https://github.com/weaveworks/grafanalib/issues/601.
Found correct value here: https://github.com/grafana/grafana/blob/6393ef93857d33073147d7f6ee73dcc976d40c25/pkg/services/ngalert/models/alert_rule.go#L62C5-L62C5.
Tested it with Grafana version `9.5.2`

## Questions
I assume we do not want to reuse variables and rather point them out explicitly but not sure about it. 