### PR TITLE
Added support for Azure Data Explorer datasource plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 * Extended SqlTarget to support parsing queries from files
 * Fix AlertCondition backwards compatibility (``useNewAlerts`` default to ``False``)
 * Added RateMetricAgg_ for ElasticSearch
+* Added support for Azure Data Explorer datasource plugin (https://github.com/grafana/azure-data-explorer-datasource)
 
 .. _`Bar_Chart`: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/
 .. _`RateMetricAgg`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html

--- a/grafanalib/azuredataexplorer.py
+++ b/grafanalib/azuredataexplorer.py
@@ -1,0 +1,41 @@
+"""Helpers to create Azure Data Explorer specific Grafana queries."""
+
+import attr
+
+TIME_SERIES_RESULT_FORMAT = 'time_series'
+TABLE_RESULT_FORMAT = 'table'
+ADX_TIME_SERIES_RESULT_FORMAT = 'time_series_adx_series'
+
+
+@attr.s
+class AzureDataExplorerTarget(object):
+    """
+    Generates Azure Data Explorer target JSON structure.
+
+    Link to Azure Data Explorer datasource Grafana plugin:
+    https://grafana.com/grafana/plugins/grafana-azure-data-explorer-datasource/
+
+    Azure Data Explorer docs on query language (KQL):
+    https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
+
+    :param database: Database to execute query on
+    :param query: Query in Kusto Query Language (KQL)
+    :param resultFormat: Output format of the query result
+    :param alias: legend alias
+    :param refId: target reference id
+    """
+
+    database = attr.ib(default="")
+    query = attr.ib(default="")
+    resultFormat = attr.ib(default=TIME_SERIES_RESULT_FORMAT)
+    alias = attr.ib(default="")
+    refId = attr.ib(default="")
+
+    def to_json_data(self):
+        return {
+            'database': self.database,
+            'query': self.query,
+            'resultFormat': self.resultFormat,
+            'alias': self.alias,
+            'refId': self.refId
+        }

--- a/grafanalib/tests/test_azuredataexplorer.py
+++ b/grafanalib/tests/test_azuredataexplorer.py
@@ -1,0 +1,18 @@
+import grafanalib.core as G
+import grafanalib.azuredataexplorer as A
+from grafanalib import _gen
+from io import StringIO
+
+
+def test_serialization_azuredataexplorer_metrics_target():
+    """Serializing a graph doesn't explode."""
+    graph = G.Graph(
+        title="Azure Data Explorer graph",
+        dataSource="default",
+        targets=[
+            A.AzureDataExplorerTarget()
+        ],
+    )
+    stream = StringIO()
+    _gen.write_dashboard(graph, stream)
+    assert stream.getvalue() != ''


### PR DESCRIPTION
## What does this do?
Add support for Azure Data Explorer queries in grafanalib

## Why is it a good idea?
Azure Data Explorer is [offered as a plugin datasource in Grafana](https://grafana.com/grafana/plugins/grafana-azure-data-explorer-datasource/) and adding this will let people create graphs based on data from Azure Data Explorer.

## Context
[Azure Data Explorer](https://docs.microsoft.com/en-us/azure/data-explorer/) is a log analytics cloud platform optimized for ad-hoc big data queries.
