### PR TITLE
Added sortBy parameter to Table panel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 * Added RateMetricAgg_ for ElasticSearch
 * added axisSoftMin and axisSoftMax options for TimeSeries
 * Added support for Azure Data Explorer datasource plugin (https://github.com/grafana/azure-data-explorer-datasource)
+* Added ``sortBy`` parameter to Table panel
 
 .. _`Bar_Chart`: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-chart/
 .. _`RateMetricAgg`: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3186,6 +3186,18 @@ class Column(object):
 
 
 @attr.s
+class TableSortByField(object):
+    displayName = attr.ib(default="")
+    desc = attr.ib(default=False)
+
+    def to_json_data(self):
+        return {
+            'displayName': self.displayName,
+            'desc': self.desc,
+        }
+
+
+@attr.s
 class Table(Panel):
     """Generates Table panel json structure
 
@@ -3203,6 +3215,7 @@ class Table(Panel):
     :param overrides: To override the base characteristics of certain data
     :param showHeader: Show the table header
     :param unit: units
+    :param sortBy: Sort rows by table fields
     """
 
     align = attr.ib(default='auto', validator=instance_of(str))
@@ -3216,6 +3229,10 @@ class Table(Panel):
     showHeader = attr.ib(default=True, validator=instance_of(bool))
     span = attr.ib(default=6),
     unit = attr.ib(default='', validator=instance_of(str))
+    sortBy = attr.ib(default=attr.Factory(list), validator=attr.validators.deep_iterable(
+        member_validator=instance_of(TableSortByField),
+        iterable_validator=instance_of(list)
+    ))
 
     @classmethod
     def with_styled_columns(cls, columns, styles=None, **kwargs):
@@ -3247,7 +3264,8 @@ class Table(Panel):
                 'mappings': self.mappings,
                 'minSpan': self.minSpan,
                 'options': {
-                    'showHeader': self.showHeader
+                    'showHeader': self.showHeader,
+                    'sortBy': self.sortBy
                 },
                 'type': TABLE_TYPE,
             }


### PR DESCRIPTION
## What does this do?
This change allows sorting table rows by their fields

## Why is it a good idea?
This is a useful feature which is supported in grafana v8:
https://grafana.com/docs/grafana/v8.0/panels/visualizations/table/#sort-column

## Context
`sortBy` in grafana's Table panel options:
https://github.com/grafana/grafana/blob/v8.0.x/public/app/plugins/panel/table/models.gen.ts#L17

The name for `TableSortByField` was inspired by the matching type in grafana:
https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Table/types.ts#L24
