### PR TITLE
Main improved dashboard links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog
 0.x.x (?)
 ==================
 
+* Extended DashboardLink to support links to dashboards and urls, as per the docs_
+
+.. _`docs`: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/#dashboard-links
+
 * Added ...
 * Added Minimum option for Timeseries
 * Added Maximum option for Timeseries

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -12,7 +12,7 @@ import math
 import string
 import warnings
 from numbers import Number
-from typing import Literal, Optional
+from typing import Literal
 
 import attr
 from attr.validators import in_, instance_of
@@ -879,33 +879,62 @@ class ConstantInput(object):
 
 @attr.s
 class DashboardLink(object):
-    as_dropdown = attr.ib(default=False, validator=instance_of(bool))
-    dashboard = attr.ib()
+    """Create a link to other dashboards, or external resources.
+
+    Dashboard Links come in two flavours; a list of dashboards, or a direct 
+    link to an arbitrary URL. These are controlled by the ``type`` parameter. 
+    A dashboard list targets a given set of tags, whereas for a link you must 
+    also provide the URL.
+
+    See `the documentation <https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/#dashboard-links>`
+    for more information.
+
+    :param asDropdown: Controls if the list appears in a dropdown rather than
+        tiling across the dashboard. Affects dashboard_list type only. Defaults
+        to False
+    :param icon: Set the icon, from a predefined list. See
+        ``grafanalib.core.DASHBOARD_LINK_ICON`` for allowed values. Affects
+        the 'link' type only. Defaults to 'external link'
+    :param includeVars: Controls if data variables from the current dashboard
+        are passed as query parameters to the linked target. Defaults to False
+    :param keepTime: Controls if the current time range is passed as query
+        parameters to the linked target. Defaults to False
+    :param tags: A list of tags used to select dashboards for the link.
+        Affects the 'dashboard_list' type only. Defaults to an empty list
+    :param targetBlank: Controls if the link opens in a new tab. Defaults
+        to False
+    :param tooltip: Tooltip text that appears when hovering over the link.
+        Affects the 'link' type only. Defaults to an empty string
+    :param type: Controls the type of DashboardLink generated. Must be
+        one of 'dashboard_list' or 'link'.
+    :param uri: The url target of the external link. Affects the 'link'
+        type only.
+    """
+    asDropdown = attr.ib(default=False, validator=instance_of(bool))
     icon = attr.ib(default='external link', type=DASHBOARD_LINK_ICON,
                    validator=in_(DASHBOARD_LINK_ICON.__args__))
-    include_vars = attr.ib(default=False, validator=instance_of(bool))
+    includeVars = attr.ib(default=False, validator=instance_of(bool))
     keepTime = attr.ib(
         default=True,
         validator=instance_of(bool),
     )
     tags = attr.ib(factory=list, type=list[str])
-    target_blank = attr.ib(default=False, validator=instance_of(bool))
-    title = attr.ib(default=None, type=Optional[str])
+    targetBlank = attr.ib(default=False, validator=instance_of(bool))
+    title = attr.ib(default="", type=str)
     tooltip = attr.ib(default="", type=str, validator=instance_of(str))
     type = attr.ib(default='dashboard', type=DASHBOARD_TYPE,
                    validator=in_(DASHBOARD_TYPE.__args__))
     uri = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
-        title = self.dashboard if self.title is None else self.title
         return {
-            'asDropdown': self.as_dropdown,
+            'asDropdown': self.asDropdown,
             'icon': self.icon,
-            'includeVars': self.include_vars,
+            'includeVars': self.includeVars,
             'keepTime': self.keepTime,
             'tags': self.tags,
-            'targetBlank': self.target_blank,
-            'title': title,
+            'targetBlank': self.targetBlank,
+            'title': self.title,
             'tooltip': self.tooltip,
             'type': self.type,
             'uri': self.uri

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -918,11 +918,11 @@ class DashboardLink(object):
         default=True,
         validator=instance_of(bool),
     )
-    tags: list[str] = attr.ib(factory=list)
+    tags: list[str] = attr.ib(factory=list, validator=instance_of(list))
     targetBlank: bool = attr.ib(default=False, validator=instance_of(bool))
     title: str = attr.ib(default="")
     tooltip: str = attr.ib(default="", validator=instance_of(str))
-    type: DASHBOARD_TYPE = attr.ib(default='dashboard',
+    type: DASHBOARD_TYPE = attr.ib(default='dashboards',
                                    validator=in_(DASHBOARD_TYPE.__args__))
     uri: str = attr.ib(default="", validator=instance_of(str))
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -890,7 +890,7 @@ class DashboardLink(object):
     for more information.
 
     :param asDropdown: Controls if the list appears in a dropdown rather than
-        tiling across the dashboard. Affects dashboard_list type only. Defaults
+        tiling across the dashboard. Affects 'dashboards' type only. Defaults
         to False
     :param icon: Set the icon, from a predefined list. See
         ``grafanalib.core.DASHBOARD_LINK_ICON`` for allowed values. Affects
@@ -900,13 +900,13 @@ class DashboardLink(object):
     :param keepTime: Controls if the current time range is passed as query
         parameters to the linked target. Defaults to False
     :param tags: A list of tags used to select dashboards for the link.
-        Affects the 'dashboard_list' type only. Defaults to an empty list
+        Affects the 'dashboards' type only. Defaults to an empty list
     :param targetBlank: Controls if the link opens in a new tab. Defaults
         to False
     :param tooltip: Tooltip text that appears when hovering over the link.
         Affects the 'link' type only. Defaults to an empty string
     :param type: Controls the type of DashboardLink generated. Must be
-        one of 'dashboard_list' or 'link'.
+        one of 'dashboards' or 'link'.
     :param uri: The url target of the external link. Affects the 'link'
         type only.
     """

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -937,7 +937,7 @@ class DashboardLink(object):
             'title': self.title,
             'tooltip': self.tooltip,
             'type': self.type,
-            'uri': self.uri
+            'url': self.uri
         }
 
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -910,21 +910,21 @@ class DashboardLink(object):
     :param uri: The url target of the external link. Affects the 'link'
         type only.
     """
-    asDropdown = attr.ib(default=False, validator=instance_of(bool))
-    icon = attr.ib(default='external link', type=DASHBOARD_LINK_ICON,
-                   validator=in_(DASHBOARD_LINK_ICON.__args__))
-    includeVars = attr.ib(default=False, validator=instance_of(bool))
-    keepTime = attr.ib(
+    asDropdown: bool = attr.ib(default=False, validator=instance_of(bool))
+    icon: DASHBOARD_LINK_ICON = attr.ib(default='external link',
+                                        validator=in_(DASHBOARD_LINK_ICON.__args__))
+    includeVars: bool = attr.ib(default=False, validator=instance_of(bool))
+    keepTime: bool = attr.ib(
         default=True,
         validator=instance_of(bool),
     )
-    tags = attr.ib(factory=list, type=list[str])
-    targetBlank = attr.ib(default=False, validator=instance_of(bool))
-    title = attr.ib(default="", type=str)
-    tooltip = attr.ib(default="", type=str, validator=instance_of(str))
-    type = attr.ib(default='dashboard', type=DASHBOARD_TYPE,
-                   validator=in_(DASHBOARD_TYPE.__args__))
-    uri = attr.ib(default="", validator=instance_of(str))
+    tags: list[str] = attr.ib(factory=list)
+    targetBlank: bool = attr.ib(default=False, validator=instance_of(bool))
+    title: str = attr.ib(default="")
+    tooltip: str = attr.ib(default="", validator=instance_of(str))
+    type: DASHBOARD_TYPE = attr.ib(default='dashboard',
+                                   validator=in_(DASHBOARD_TYPE.__args__))
+    uri: str = attr.ib(default="", validator=instance_of(str))
 
     def to_json_data(self):
         return {

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -881,9 +881,9 @@ class ConstantInput(object):
 class DashboardLink(object):
     """Create a link to other dashboards, or external resources.
 
-    Dashboard Links come in two flavours; a list of dashboards, or a direct 
-    link to an arbitrary URL. These are controlled by the ``type`` parameter. 
-    A dashboard list targets a given set of tags, whereas for a link you must 
+    Dashboard Links come in two flavours; a list of dashboards, or a direct
+    link to an arbitrary URL. These are controlled by the ``type`` parameter.
+    A dashboard list targets a given set of tags, whereas for a link you must
     also provide the URL.
 
     See `the documentation <https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/#dashboard-links>`

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1190,3 +1190,36 @@ def test_sql_target_with_source_files():
     assert t.to_json_data()["targets"][0].rawQuery is True
     assert t.to_json_data()["targets"][0].rawSql == "SELECT example\nFROM test\nWHERE example='example' AND example_date BETWEEN '1970-01-01' AND '1971-01-01';\n"
     print(t.to_json_data()["targets"][0])
+
+class TestDashboardLink():
+
+    def test_validators(self):
+        with pytest.raises(ValueError):
+            G.DashboardLink(
+                type='dashboard',
+            )
+        with pytest.raises(ValueError):
+            G.DashboardLink(
+                icon='not an icon'
+            )
+
+    def test_initialisation(self):
+        dl = G.DashboardLink().to_json_data()
+        assert dl['asDropdown'] is False
+        assert dl['icon'] == 'external link'
+        assert dl['includeVars'] is False
+        assert dl['keepTime'] is True
+        assert not dl['tags']
+        assert dl['targetBlank'] is False
+        assert dl['title'] == ""
+        assert dl['tooltip'] == ""
+        assert dl['type'] == 'dashboards'
+        assert dl['url'] == ""
+
+        url = 'https://grafana.com'
+        dl = G.DashboardLink(
+            uri=url,
+            type='link'
+        ).to_json_data()
+        assert dl['url'] == url
+        assert dl['type'] == 'link'

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1191,6 +1191,7 @@ def test_sql_target_with_source_files():
     assert t.to_json_data()["targets"][0].rawSql == "SELECT example\nFROM test\nWHERE example='example' AND example_date BETWEEN '1970-01-01' AND '1971-01-01';\n"
     print(t.to_json_data()["targets"][0])
 
+
 class TestDashboardLink():
 
     def test_validators(self):


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Extends the implementation of DashboardLink to support creating both direct links and lists of dashboards.

## Why is it a good idea?
This enables grafanalib users to fully employ the DashboardLink feature. The previous JSON model was no longer accurate for recent grafana versions, meaning dashboard links were not properly generated. Here we add all available fields, allowing users to create dashboard links correctly from grafanalib.

## Context
Dashboard Links are a way to create links along the top of a dashboard, linking either to other sets of dashboards from the same organization or arbitrary external resources. See the documentation here: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/#manage-dashboard-links

## Questions
I have removed a parameter from the old DashboardLink class, `dashboard`; this could consistute a breaking change.

This parameter was not actually consumed by Grafana, so was in effect only acting as an internal alias to the `title` field. The `title` would only be shown if the `DashboardLink.type` attribute is set to `link`, something actually not possible before this PR. so I don't consider it to be a significant change. But, if desired, we can retain that alias-like behaviour to maintain API compatability.
