### PR TITLE
Main add graph unit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 ==================
 
 * Added ...
+* Add Unit option for Graph panel
 * Added Minimum option for Timeseries
 * Added Maximum option for Timeseries
 * Added Number of decimals displays option for Timeseries

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -2059,7 +2059,7 @@ class Graph(Panel):
     :param stack: Each series is stacked on top of another
     :param percentage: Available when Stack is selected. Each series is drawn as a percentage of the total of all series
     :param thresholds: List of GraphThresholds - Only valid when alert not defined
-
+    :param unit: Set Y Axis Unit
     """
 
     alert = attr.ib(default=None)
@@ -2093,6 +2093,7 @@ class Graph(Panel):
         validator=instance_of(Tooltip),
     )
     thresholds = attr.ib(default=attr.Factory(list))
+    unit = attr.ib(default='', validator=instance_of(str))
     xAxis = attr.ib(default=attr.Factory(XAxis), validator=instance_of(XAxis))
     try:
         yAxes = attr.ib(
@@ -2112,6 +2113,11 @@ class Graph(Panel):
             'aliasColors': self.aliasColors,
             'bars': self.bars,
             'error': self.error,
+            'fieldConfig': {
+                'defaults': {
+                    'unit': self.unit
+                },
+            },
             'fill': self.fill,
             'grid': self.grid,
             'isNew': self.isNew,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

With thanks to my colleagues Damiano Gianotti (https://github.com/D3mianGianoz) and Ianthe Michiels.

## What does this do?
Adds the option to specify the unit for a standard `core.Graph` panel. This feature was implemented for the `core.TimeSeries` panel, but not yet for `Graph`.

## Why is it a good idea?
It brings a bit of feature parity between the two standard panel types.

## Context
For older grafana versions, Graph is the default visualisation, and is still supported (if deprecated). Having feature parity between the two panel types makes it easier to then transition to the TimeSeries panel in the future.

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
