### PR TITLE
Add 'auto' to the list of accepted orientations for BarGauge.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changelog
 * Added unit parameter to the Table class in core
 * Added a hide parameter to ElasticsearchTarget
 * Fix value literal GAUGE_CALC_TOTAL to sum instead of total
+* Fix `BarGauge` orientation validation to accept `'auto'`
 
 0.7.0 (2022-10-02)
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -289,6 +289,7 @@ GAUGE_CALC_DISTINCT_COUNT = 'distinctCount'
 
 ORIENTATION_HORIZONTAL = 'horizontal'
 ORIENTATION_VERTICAL = 'vertical'
+ORIENTATION_AUTO = 'auto'
 
 GAUGE_DISPLAY_MODE_BASIC = 'basic'
 GAUGE_DISPLAY_MODE_LCD = 'lcd'
@@ -3371,7 +3372,9 @@ class BarGauge(Panel):
     min = attr.ib(default=0)
     orientation = attr.ib(
         default=ORIENTATION_HORIZONTAL,
-        validator=in_([ORIENTATION_HORIZONTAL, ORIENTATION_VERTICAL]),
+        validator=in_([ORIENTATION_HORIZONTAL,
+                       ORIENTATION_VERTICAL,
+                       ORIENTATION_AUTO]),
     )
     rangeMaps = attr.ib(default=attr.Factory(list))
     thresholdLabels = attr.ib(default=False, validator=instance_of(bool))


### PR DESCRIPTION
## What does this do?
Extends the list of accepted orientations in BarGauge to include auto: https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/bar-gauge/#orientation

## Why is it a good idea?
This allows grafanalib's range to cover a more complete set of valid grafana configurations.

## Context
https://github.com/weaveworks/grafanalib/issues/634

## Questions

