### PR TITLE
Heatmap default options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 .. _`docs`: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-dashboard-links/#dashboard-links
 
 * Added ...
+* Fix default options for Heatmap
 * Add Unit option for Graph panel
 * Added Minimum option for Timeseries
 * Added Maximum option for Timeseries

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3561,7 +3561,7 @@ class Heatmap(Panel):
     heatmap = {}
     hideZeroBuckets = attr.ib(default=False)
     highlightCards = attr.ib(default=True)
-    options = attr.ib(default=None)
+    options = attr.ib(default=attr.Factory(list))
 
     xAxis = attr.ib(
         default=attr.Factory(XAxis),

--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -1192,6 +1192,12 @@ def test_sql_target_with_source_files():
     print(t.to_json_data()["targets"][0])
 
 
+def test_default_heatmap():
+    h = G.Heatmap()
+
+    assert h.to_json_data()["options"] == []
+
+
 class TestDashboardLink():
 
     def test_validators(self):


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?

Set default Heatmap options to an empty list instead of null.

## Why is it a good idea?

Older versions of Grafana (e.g. v10.2) fail on empty Heatmap options (for newer version this is already fixed in Grafana https://github.com/grafana/grafana/pull/79083)
