### PR TITLE
feat: add grafana v10 AlertRule support

### DIFF
--- a/grafanalib/tests/test_core.py
+++ b/grafanalib/tests/test_core.py
@@ -908,6 +908,47 @@ def test_alertrulev9():
     assert data['grafana_alert']['condition'] == condition
 
 
+def test_alertrulev10():
+    title = "My Important Alert!"
+    annotations = {"summary": "this alert fires when prod is down!!!"}
+    labels = {"severity": "serious"}
+    condition = 'C'
+    rule = G.AlertRulev10(
+        title=title,
+        uid='alert1',
+        condition=condition,
+        triggers=[
+            G.Target(
+                expr='query',
+                refId='A',
+                datasource='Prometheus',
+            ),
+            G.AlertExpression(
+                refId='B',
+                expressionType=G.EXP_TYPE_CLASSIC,
+                expression='A',
+                conditions=[
+                    G.AlertCondition(
+                        evaluator=G.GreaterThan(3),
+                        operator=G.OP_AND,
+                        reducerType=G.RTYPE_LAST
+                    )
+                ]
+            ),
+        ],
+        annotations=annotations,
+        labels=labels,
+        evaluateFor="3m",
+    )
+
+    data = rule.to_json_data()
+    assert data['annotations'] == annotations
+    assert data['labels'] == labels
+    assert data['for'] == "3m"
+    assert data['title'] == title
+    assert data['condition'] == condition
+
+
 def test_alertexpression():
     refId = 'D'
     expression = 'C'


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
Grafana v10 has a slightly different format for alert rules, so the v9 version of the class cannot be used without overriding the to_json_data method. The PR implements the modified rendering that should work for grafana v10 alerts

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
Supporting v10 will help keeping the library relevant in the short term while [cog](https://github.com/grafana/cog) matures. Once cog become mature enough, it might be an interesting option, but for now manual code changes are still the best way to go forward

## Context
<!-- any background that might help the reviewer understand what's going on -->
See #627

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
