### PR TITLE
Target alias

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x ?
 ==================
 
-* Added ...
+* Added support `alias` via the `legendFormat` option for `Target`
 
 0.7.1 2024-01-12
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -573,6 +573,7 @@ class Target(object):
     Metric to show.
 
     :param target: Graphite way to select data
+    :param legendFormat: Target alias. Prometheus use legendFormat, other like Influx use alias. This set legendFormat as well as alias.
     """
 
     expr = attr.ib(default="")
@@ -598,6 +599,7 @@ class Target(object):
             'interval': self.interval,
             'intervalFactor': self.intervalFactor,
             'legendFormat': self.legendFormat,
+            'alias': self.legendFormat,
             'metric': self.metric,
             'refId': self.refId,
             'step': self.step,


### PR DESCRIPTION
## What does this do?
Some targets (Influx for example) use `alias` instead of `legendFormat` (which is Prometheus "alias"). This commit setup both of them by current `legendFormat`.

## Why is it a good idea?
For Influxdb `SqlTarget` isn't now possible to set "alias" via `Target`. Of course is possible to use `InfluxDBTarget` (https://github.com/weaveworks/grafanalib/blob/main/grafanalib/influxdb.py) but there missing other options (like `hide`, because it's not child of `Target`). So I've chosen solution to extend `Target` to support all needed for my influx.

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
If you don't like this solution, I see other solutions
1. add new `alias` option - similar as #285 
2. InfluxDBTarget class should be inherit from `Target`