### PR TITLE
Neutral option for GaugePanel

### DIFF
--- a/.github/workflows/check-sphinx-and-links.yml
+++ b/.github/workflows/check-sphinx-and-links.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Link Checker
       id: lc
-      uses: lycheeverse/lychee-action@v1.9.1
+      uses: lycheeverse/lychee-action@v1.9.3
       with:
         args: --verbose **/*.html
     - name: Fail if there were link errors

--- a/.github/workflows/check-sphinx-and-links.yml
+++ b/.github/workflows/check-sphinx-and-links.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Link Checker
       id: lc
-      uses: lycheeverse/lychee-action@v1.8.0
+      uses: lycheeverse/lychee-action@v1.9.1
       with:
         args: --verbose **/*.html
     - name: Fail if there were link errors

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x ?
 ==================
 
-* Added ...
+* Added `neutral` option for `GaugePanel` (supported by Grafana 9.3.0 - https://github.com/grafana/grafana/discussions/38273)
 
 0.7.1 2024-01-12
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3439,6 +3439,7 @@ class GaugePanel(Panel):
     :param thresholdMarkers: option to show marker of level on gauge
     :param thresholds: single stat thresholds
     :param valueMaps: the list of value to text mappings
+    :param neutral: neutral point of gauge, leave empty to use Min as neutral point
     """
 
     allValues = attr.ib(default=False, validator=instance_of(bool))
@@ -3463,6 +3464,7 @@ class GaugePanel(Panel):
         validator=instance_of(list),
     )
     valueMaps = attr.ib(default=attr.Factory(list))
+    neutral = attr.ib(default=None)
 
     def to_json_data(self):
         return self.panel_json(
@@ -3480,6 +3482,9 @@ class GaugePanel(Panel):
                         'mappings': self.valueMaps,
                         'override': {},
                         'values': self.allValues,
+                        'custom': {
+                            'neutral': self.neutral,
+                        },
                     },
                     'showThresholdLabels': self.thresholdLabels,
                     'showThresholdMarkers': self.thresholdMarkers,


### PR DESCRIPTION
## What does this do?
Added `neutral` option for `GaugePanel` (supported by Grafana 9.3.0 
 - https://github.com/grafana/grafana/discussions/38273)

## Why is it a good idea?
Why it's good idea is described in the grafana discussion https://github.com/grafana/grafana/discussions/38273.  In this commit just add it as option to set.