### PR TITLE
chore: Update project metadata to reflect minimum Python version 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Dear maintainers,

coming from GH-650, this package is no longer compatible with Python 3.7 after starting to use `typing.Literal` recently. This patch accounts for that by adjusting the project metadata correspondingly.

