### PR TITLE
maintenance: Verify support for Python 3.12

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5.0.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Build a binary wheel and a source tarball
       run: >-
         pip install wheel;

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x ?
 ==================
 
-* Added ...
+* Verify support for Python 3.12
 
 0.7.1 2024-01-12
 ==================

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: System :: Monitoring',
     ],
     install_requires=[


### PR DESCRIPTION
Hi again,

accompanying GH-652, this patch intends to "add" support for Python 3.12, by verifying it on CI (909b32fe5). Other than this main change, 731f1c7d0af also bumps the Python version on the package publishing CI task.

With kind regards,
Andreas.
