### PR TITLE
AlertRulev9 supports dashbord_uid and panel_uid.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x ?
 ==================
 
-* Added ...
+* AlertRulev9 propagates dashbord_uid and panel_uid to the alert rule
 
 0.7.1 2024-01-12
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1696,6 +1696,12 @@ class AlertRulev9(object):
             else:
                 data += [trigger.to_json_data()]
 
+
+        if self.dashboard_uid:
+            self.annotations['__dashboardUid__'] = self.dashboard_uid
+        if self.panel_id:
+            self.annotations['__panelId__'] = f"{self.panel_id}"
+
         return {
             "uid": self.uid,
             "for": self.evaluateFor,
@@ -1708,6 +1714,8 @@ class AlertRulev9(object):
                 "no_data_state": self.noDataAlertState,
                 "exec_err_state": self.errorAlertState,
             },
+            "dashboardUid": self.dashboard_uid,
+            "panelId": self.panel_id,
         }
 
 


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
Add link from alert rule to the dashboard and panel.

## Why is it a good idea?
Those options was avaialable, but wasn't used and generated alert doesn't have connection to the dashboard and panel. By this fix it's possible.

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
