### PR TITLE
cloudwatch: add queryMode attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,10 @@
 Changelog
 =========
 
-x.x.x ?
+0.7.2 ?
 ==================
 
-* Added ...
+* Add `QueryMode` parameter in CloudwatchMetricsTarget
 
 0.7.1 2024-01-12
 ==================

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -31,6 +31,7 @@ class CloudwatchMetricsTarget(Target):
     :param statistic: Cloudwatch mathematic statistic
     :param hide: controls if given metric is displayed on visualization
     :param datasource: Grafana datasource name
+    :param queryMode: queryMode for cloudwatch metric request
     """
 
     alias = attr.ib(default="")

--- a/grafanalib/cloudwatch.py
+++ b/grafanalib/cloudwatch.py
@@ -32,6 +32,7 @@ class CloudwatchMetricsTarget(Target):
     :param hide: controls if given metric is displayed on visualization
     :param datasource: Grafana datasource name
     """
+
     alias = attr.ib(default="")
     dimensions = attr.ib(factory=dict, validator=instance_of(dict))
     expression = attr.ib(default="")
@@ -46,9 +47,9 @@ class CloudwatchMetricsTarget(Target):
     statistic = attr.ib(default="Average")
     hide = attr.ib(default=False, validator=instance_of(bool))
     datasource = attr.ib(default=None)
+    queryMode = attr.ib(default="")
 
     def to_json_data(self):
-
         return {
             "alias": self.alias,
             "dimensions": self.dimensions,
@@ -64,6 +65,7 @@ class CloudwatchMetricsTarget(Target):
             "statistic": self.statistic,
             "hide": self.hide,
             "datasource": self.datasource,
+            "queryMode": self.queryMode,
         }
 
 
@@ -88,6 +90,7 @@ class CloudwatchLogsInsightsTarget(Target):
     :param hide: controls if given metric is displayed on visualization
     :param datasource: Grafana datasource name
     """
+
     expression = attr.ib(default="")
     id = attr.ib(default="")
     logGroupNames = attr.ib(factory=list, validator=instance_of(list))
@@ -99,7 +102,6 @@ class CloudwatchLogsInsightsTarget(Target):
     datasource = attr.ib(default=None)
 
     def to_json_data(self):
-
         return {
             "expression": self.expression,
             "id": self.id,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
To generate certain dashboards with the Cloudwatch datasource, specify the queryMode

## Why is it a good idea?
Fix a simple issue

## Context
For many queries I need this option

