### PR TITLE
add mappings to field config for Table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Changelog
 =========
 
 x.x.x ?
+* Fix mappings for Table
+
 ==================
 
 * Added ...

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3312,7 +3312,8 @@ class Table(Panel):
                             'displayMode': self.displayMode,
                             'filterable': self.filterable,
                         },
-                        'unit': self.unit
+                        'unit': self.unit,
+                        'mappings': self.mappings
                     },
                     'overrides': self.overrides
                 },


### PR DESCRIPTION
## What does this do?
This change enables you to configure value mappings for Table. Previously, the `mappings` argument provided would just get ignored.

## Questions
I am not sure about backwards compatibility, but I am using Grafana v9.4.7 and it expects `mappings` in this location.
