### PR TITLE
fix: correct spelling errors for temperature units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 x.x.x ?
 =======
 
+* **Breaking change:** Fixed spelling errors for temperature units, corrected 'CELSUIS' to 'CELSIUS' and 'FARENHEIT' to 'FAHRENHEIT'.
 * Added ``tooltipSort`` parameter to PieChartv2 panel
 * Fix mappings for Table
 * Added support for AWS Cross-Account in CloudwatchMetricsTarget

--- a/grafanalib/formatunits.py
+++ b/grafanalib/formatunits.py
@@ -238,9 +238,9 @@ HERTZ_ROTATION = 'rothz'        # Hz
 RADS_PER_SEC = 'rotrads'        # rad/s
 DEGREES_PER_SECOND = 'rotdegs'  # °/s
 # Temperature
-CELSUIS = 'celsius'       # °C
-FARENHEIT = 'fahrenheit'  # °F
-KELVIN = 'kelvin'         # K
+CELSIUS = 'celsius'        # °C
+FAHRENHEIT = 'fahrenheit'  # °F
+KELVIN = 'kelvin'          # K
 # Time
 HERTZ = 'hertz'  # Hz
 NANO_SECONDS = 'ns'   # ns


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?

This PR corrects the spelling errors for temperature units in `formatunits.py`:

- `CELSUIS` to `CELSIUS`
- `FARENHEIT` to `FAHRENHEIT`

## Questions

- This a breaking change. Anything specific to handle it?