### PR TITLE
Extend GaugePanel options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ x.x.x ?
 * Fix mappings for Table
 * Added support for AWS Cross-Account in CloudwatchMetricsTarget
 * Added `LokiTarget`
+* Added `color`, `fieldMinMax`, and `thresholdType` option for `GaugePanel`
 
 0.7.1 2024-01-12
 ================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3455,6 +3455,7 @@ class GaugePanel(Panel):
     :param color: color mode
     :param dataLinks: list of data links hooked to datapoints on the graph
     :param decimals: override automatic decimal precision for legend/tooltips
+    :param fieldMinMax: force disable/enable min max values
     :param format: defines value units
     :param labels: option to show gauge level labels
     :param limit: limit of number of values to show when not Calculating
@@ -3467,6 +3468,7 @@ class GaugePanel(Panel):
     :param thresholdType: threshold mode
     :param thresholds: single stat thresholds
     :param valueMaps: the list of value to text mappings
+    :param neutral: neutral point of gauge, leave empty to use Min as neutral point
     """
 
     allValues = attr.ib(default=False, validator=instance_of(bool))
@@ -3478,8 +3480,8 @@ class GaugePanel(Panel):
     format = attr.ib(default='none')
     label = attr.ib(default=None)
     limit = attr.ib(default=None)
-    max = attr.ib(default=0)
-    min = attr.ib(default=100)
+    max = attr.ib(default=100)
+    min = attr.ib(default=0)
     rangeMaps = attr.ib(default=attr.Factory(list))
     thresholdLabels = attr.ib(default=False, validator=instance_of(bool))
     thresholdMarkers = attr.ib(default=True, validator=instance_of(bool))
@@ -3493,8 +3495,8 @@ class GaugePanel(Panel):
         ),
         validator=instance_of(list),
     )
-
     valueMaps = attr.ib(default=attr.Factory(list))
+    neutral = attr.ib(default=None)
 
     def to_json_data(self):
         return self.panel_json(
@@ -3514,6 +3516,9 @@ class GaugePanel(Panel):
                         'mappings': self.valueMaps,
                         'override': {},
                         'values': self.allValues,
+                        'custom': {
+                            'neutral': self.neutral,
+                        },
                     },
                     'showThresholdLabels': self.thresholdLabels,
                     'showThresholdMarkers': self.thresholdMarkers,

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -3452,6 +3452,7 @@ class GaugePanel(Panel):
 
     :param allValue: If All values should be shown or a Calculation
     :param calc: Calculation to perform on metrics
+    :param color: color mode
     :param dataLinks: list of data links hooked to datapoints on the graph
     :param decimals: override automatic decimal precision for legend/tooltips
     :param format: defines value units
@@ -3463,23 +3464,26 @@ class GaugePanel(Panel):
     :param thresholdLabel: label for gauge. Template Variables:
         "$__series_namei" "$__field_name" "$__cell_{N} / $__calc"
     :param thresholdMarkers: option to show marker of level on gauge
+    :param thresholdType: threshold mode
     :param thresholds: single stat thresholds
     :param valueMaps: the list of value to text mappings
-    :param neutral: neutral point of gauge, leave empty to use Min as neutral point
     """
 
     allValues = attr.ib(default=False, validator=instance_of(bool))
     calc = attr.ib(default=GAUGE_CALC_MEAN)
+    color = attr.ib(default=None)
     dataLinks = attr.ib(default=attr.Factory(list))
     decimals = attr.ib(default=None)
+    fieldMinMax = attr.ib(default=None)
     format = attr.ib(default='none')
     label = attr.ib(default=None)
     limit = attr.ib(default=None)
-    max = attr.ib(default=100)
-    min = attr.ib(default=0)
+    max = attr.ib(default=0)
+    min = attr.ib(default=100)
     rangeMaps = attr.ib(default=attr.Factory(list))
     thresholdLabels = attr.ib(default=False, validator=instance_of(bool))
     thresholdMarkers = attr.ib(default=True, validator=instance_of(bool))
+    thresholdType = attr.ib(default='absolute')
     thresholds = attr.ib(
         default=attr.Factory(
             lambda: [
@@ -3489,8 +3493,8 @@ class GaugePanel(Panel):
         ),
         validator=instance_of(list),
     )
+
     valueMaps = attr.ib(default=attr.Factory(list))
-    neutral = attr.ib(default=None)
 
     def to_json_data(self):
         return self.panel_json(
@@ -3498,7 +3502,9 @@ class GaugePanel(Panel):
                 'fieldConfig': {
                     'defaults': {
                         'calcs': [self.calc],
+                        'color': self.color,
                         'decimals': self.decimals,
+                        'fieldMinMax': self.fieldMinMax,
                         'max': self.max,
                         'min': self.min,
                         'title': self.label,
@@ -3508,9 +3514,6 @@ class GaugePanel(Panel):
                         'mappings': self.valueMaps,
                         'override': {},
                         'values': self.allValues,
-                        'custom': {
-                            'neutral': self.neutral,
-                        },
                     },
                     'showThresholdLabels': self.thresholdLabels,
                     'showThresholdMarkers': self.thresholdMarkers,


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->
This adds `color`, `fieldMinMax`, and `thresholdType` options for `GaugePanel`

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->
More granularly control gauge presentation with color and explicitly remove min/max.
`thresholdType` exposes an attribute that otherwise quietly defaults to 'absolute' from the Panel class

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
