### PR TITLE
Allow using non-row panels in dashboard's panels

### DIFF
--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -1825,12 +1825,10 @@ class Dashboard(object):
                 yield panel
 
         for panel in self.panels:
-            if hasattr(panel, 'panels'):
-                yield panel
+            yield panel
+            if hasattr(panel, '_iter_panels'):
                 for row_panel in panel._iter_panels():
                     yield row_panel
-            else:
-                yield panel
 
     def _map_panels(self, f):
         return attr.evolve(


### PR DESCRIPTION
<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?

As discussed in https://github.com/grafana/grafana/issues/50855#issuecomment-1183431665, panels of rows with collapsed=False should be added to the list of panels that contains that row.

Adding non-row panels makes auto_panel_ids() fail with
```
  File ".../grafanalib/core.py", line 1751, in auto_panel_ids
    ids = set([panel.id for panel in self._iter_panels() if panel.id])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../grafanalib/core.py", line 1731, in _iter_panels
    for row_panel in panel._iter_panels():
                     ^^^^^^^^^^^^^^^^^^
AttributeError: 'TimeSeries' object has no attribute '_iter_panels'
```

This change fixes this exception.
