### PR TITLE
Stackdriver target

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ x.x.x ?
 * Fix mappings for Table
 * Added support for AWS Cross-Account in CloudwatchMetricsTarget
 * Added `LokiTarget`
+* Added `StackdriverTarget`
 
 0.7.1 2024-01-12
 ================

--- a/grafanalib/stackdriver.py
+++ b/grafanalib/stackdriver.py
@@ -35,11 +35,28 @@ class TimeSeriesList(object):
     TimeSeriesList for Stackdriver.
     """
 
-    alignmentPeriod = attr.ib(default=AP_CLOUD_MONITORING_AUTO, validator=in_([AP_CLOUD_MONITORING_AUTO, AP_GRAFANA_AUTO, AP_1M, AP_2M, AP_5M, AP_10M]))
-    crossSeriesReducer = attr.ib(default='REDUCE_NONE', validator=in_([CSR_REDUCE_NONE, CSR_REDUCE_MEAN, CSR_REDUCE_MAX, CSR_REDUCE_MIN, CSR_REDUCE_SUM, CSR_REDUCE_STDDEV]))
+    alignmentPeriod = attr.ib(default=AP_CLOUD_MONITORING_AUTO, validator=in_([AP_CLOUD_MONITORING_AUTO,
+                                                                               AP_GRAFANA_AUTO,
+                                                                               AP_1M,
+                                                                               AP_2M,
+                                                                               AP_5M,
+                                                                               AP_10M]))
+    crossSeriesReducer = attr.ib(default='REDUCE_NONE', validator=in_([CSR_REDUCE_NONE,
+                                                                       CSR_REDUCE_MEAN,
+                                                                       CSR_REDUCE_MAX,
+                                                                       CSR_REDUCE_MIN,
+                                                                       CSR_REDUCE_SUM,
+                                                                       CSR_REDUCE_STDDEV]))
     filters = attr.ib(default=[], validator=instance_of(list))
     groupBys = attr.ib(default=[], validator=instance_of(list))
-    perSeriesAligner = attr.ib(default=PSA_ALIGN_MEAN, validator=in_([PSA_ALIGN_NONE, PSA_ALIGN_INTERPOLATE, PSA_ALIGN_NEXT_OLDER, PSA_ALIGN_MIN, PSA_ALIGN_MAX, PSA_ALIGN_MEAN, PSA_ALIGN_STDDEV, PSA_ALIGN_PERCENTAGE]))
+    perSeriesAligner = attr.ib(default=PSA_ALIGN_MEAN, validator=in_([PSA_ALIGN_NONE,
+                                                                      PSA_ALIGN_INTERPOLATE,
+                                                                      PSA_ALIGN_NEXT_OLDER,
+                                                                      PSA_ALIGN_MIN,
+                                                                      PSA_ALIGN_MAX,
+                                                                      PSA_ALIGN_MEAN,
+                                                                      PSA_ALIGN_STDDEV,
+                                                                      PSA_ALIGN_PERCENTAGE]))
     preprocessor = attr.ib(default='none', validator=in_(['none']))
     projectName = attr.ib(default='', validator=instance_of(str))
     view = attr.ib(default='FULL', validator=in_(['FULL']))

--- a/grafanalib/stackdriver.py
+++ b/grafanalib/stackdriver.py
@@ -47,8 +47,8 @@ class TimeSeriesList(object):
                                                                        CSR_REDUCE_MIN,
                                                                        CSR_REDUCE_SUM,
                                                                        CSR_REDUCE_STDDEV]))
-    filters = attr.ib(default=[], validator=instance_of(list))
-    groupBys = attr.ib(default=[], validator=instance_of(list))
+    filters = attr.ib(default=attr.Factory(lambda: []), validator=instance_of(list))
+    groupBys = attr.ib(default=attr.Factory(lambda: []), validator=instance_of(list))
     perSeriesAligner = attr.ib(default=PSA_ALIGN_MEAN, validator=in_([PSA_ALIGN_NONE,
                                                                       PSA_ALIGN_INTERPOLATE,
                                                                       PSA_ALIGN_NEXT_OLDER,
@@ -83,7 +83,7 @@ class StackdriverTarget(object):
     datasource = attr.ib(default='', validator=instance_of(str))
     refId = attr.ib(default='', validator=instance_of(str))
     aliasBy = attr.ib(default=None, validator=instance_of(Optional[str]))
-    timeSeriesList = attr.ib(default=TimeSeriesList(), validator=instance_of(TimeSeriesList))
+    timeSeriesList = attr.ib(default=attr.Factory(TimeSeriesList), validator=instance_of(TimeSeriesList))
     metricType = attr.ib(default=None, validator=instance_of(Optional[str]))
 
     def to_json_data(self):

--- a/grafanalib/stackdriver.py
+++ b/grafanalib/stackdriver.py
@@ -1,0 +1,83 @@
+import attr
+from attr.validators import in_, instance_of
+from typing import Optional
+
+AP_CLOUD_MONITORING_AUTO = 'cloud-monitoring-auto'
+AP_GRAFANA_AUTO = 'cloud-monitoring-auto'
+AP_1M = '+60s'
+AP_2M = '+120s'
+AP_5M = '+300s'
+AP_10M = '+600s'
+AP_30M = '+1800s'
+AP_1H = '+3600s'
+AP_2H = '+7200s'
+
+CSR_REDUCE_NONE = 'REDUCE_NONE'
+CSR_REDUCE_MEAN = 'REDUCE_MEAN'
+CSR_REDUCE_MAX = 'REDUCE_MAX'
+CSR_REDUCE_MIN = 'REDUCE_MIN'
+CSR_REDUCE_SUM = 'REDUCE_SUM'
+CSR_REDUCE_STDDEV = 'REDUCE_STDDEV'
+
+PSA_ALIGN_NONE = 'ALIGN_NONE'
+PSA_ALIGN_INTERPOLATE = 'ALIGN_INTERPOLATE'
+PSA_ALIGN_NEXT_OLDER = 'ALIGN_NEXT_OLDER'
+PSA_ALIGN_MIN = 'ALIGN_MIN'
+PSA_ALIGN_MAX = 'ALIGN_MAX'
+PSA_ALIGN_MEAN = 'ALIGN_MEAN'
+PSA_ALIGN_STDDEV = 'ALIGN_STDDEV'
+PSA_ALIGN_PERCENTAGE = 'ALIGN_PERCENTAGE'
+
+
+@attr.s
+class TimeSeriesList(object):
+    """
+    TimeSeriesList for Stackdriver.
+    """
+
+    alignmentPeriod = attr.ib(default=AP_CLOUD_MONITORING_AUTO, validator=in_([AP_CLOUD_MONITORING_AUTO, AP_GRAFANA_AUTO, AP_1M, AP_2M, AP_5M, AP_10M]))
+    crossSeriesReducer = attr.ib(default='REDUCE_NONE', validator=in_([CSR_REDUCE_NONE, CSR_REDUCE_MEAN, CSR_REDUCE_MAX, CSR_REDUCE_MIN, CSR_REDUCE_SUM, CSR_REDUCE_STDDEV]))
+    filters = attr.ib(default=[], validator=instance_of(list))
+    groupBys = attr.ib(default=[], validator=instance_of(list))
+    perSeriesAligner = attr.ib(default=PSA_ALIGN_MEAN, validator=in_([PSA_ALIGN_NONE, PSA_ALIGN_INTERPOLATE, PSA_ALIGN_NEXT_OLDER, PSA_ALIGN_MIN, PSA_ALIGN_MAX, PSA_ALIGN_MEAN, PSA_ALIGN_STDDEV, PSA_ALIGN_PERCENTAGE]))
+    preprocessor = attr.ib(default='none', validator=in_(['none']))
+    projectName = attr.ib(default='', validator=instance_of(str))
+    view = attr.ib(default='FULL', validator=in_(['FULL']))
+
+    def to_json_data(self):
+        return {
+            "alignmentPeriod": self.alignmentPeriod,
+            "crossSeriesReducer": self.crossSeriesReducer,
+            "filters": self.filters,
+            "groupBys": self.groupBys,
+            "perSeriesAligner": self.perSeriesAligner,
+            "preprocessor": self.preprocessor,
+            "projectName": self.projectName,
+            "view": self.view,
+        }
+
+
+@attr.s
+class StackdriverTarget(object):
+    """
+    Target for Stackdriver.
+    """
+
+    datasource = attr.ib(default='', validator=instance_of(str))
+    refId = attr.ib(default='', validator=instance_of(str))
+    aliasBy = attr.ib(default=None, validator=instance_of(Optional[str]))
+    timeSeriesList = attr.ib(default=TimeSeriesList(), validator=instance_of(TimeSeriesList))
+    metricType = attr.ib(default=None, validator=instance_of(Optional[str]))
+
+    def to_json_data(self):
+        return {
+            'datasource': {
+                'type': 'stackdriver',
+                'uid': self.datasource,
+            },
+            'refId': self.refId,
+            'aliasBy': self.aliasBy,
+            'metricType': self.metricType,
+            'queryType': 'timeSeriesList',
+            'timeSeriesList': self.timeSeriesList.to_json_data()
+        }

--- a/grafanalib/tests/test_stackdriver.py
+++ b/grafanalib/tests/test_stackdriver.py
@@ -1,0 +1,25 @@
+"""Tests for Stackdriver Datasource"""
+
+import grafanalib.core as G
+import grafanalib.stackdriver as S
+from grafanalib import _gen
+from io import StringIO
+
+
+def test_serialization_stackdriver_metrics_target():
+    """Serializing a graph doesn't explode."""
+    graph = G.Graph(
+        title="Stackdriver Logs",
+        dataSource="Stackdriver data source",
+        targets=[
+            S.StackdriverTarget(),
+        ],
+        id=1,
+        yAxes=G.YAxes(
+            G.YAxis(format=G.SHORT_FORMAT, label="ms"),
+            G.YAxis(format=G.SHORT_FORMAT),
+        ),
+    )
+    stream = StringIO()
+    _gen.write_dashboard(graph, stream)
+    assert stream.getvalue() != ''


### PR DESCRIPTION
## What does this do?
Add Stackdriver target 

## Why is it a good idea?
Stackdriver (GCP) isn't currently supported as target in Grafanalib

## Context
Stackdriver target allows to generate dashboard for GCP, such as this:
```
  "targets": [
    {
      "aliasBy": null,
      "datasource": {
        "type": "stackdriver",
        "uid": "zzz"
      },
      "metricType": null,
      "queryType": "timeSeriesList",
      "refId": "A",
      "timeSeriesList": {
        "alignmentPeriod": "cloud-monitoring-auto",
        "crossSeriesReducer": "REDUCE_SUM",
        "filters": [
          "resource.label.project_id",
          "=",
          "my-project",
          "AND",
          "resource.label.job_name",
          "=",
          "dataflow-job",
          "AND",
          "metric.type",
          "=",
          "dataflow.googleapis.com/job/system_lag"
        ],
        "groupBys": [],
        "perSeriesAligner": "ALIGN_MAX",
        "preprocessor": "none",
        "projectName": "my-project",
        "view": "FULL"
      }
    }
  ]
```
This modification has been tested and works in many different panels.

